### PR TITLE
Finish 2-4-dev #108609514 Dropin disactivates Hosted & vice versa

### DIFF
--- a/spec/models/gateway/braintree_vzero_dropin_ui_spec.rb
+++ b/spec/models/gateway/braintree_vzero_dropin_ui_spec.rb
@@ -1,35 +1,35 @@
-# require 'spec_helper'
-#
-# describe Spree::Gateway::BraintreeVzeroDropInUI, :vcr do
-#   subject { create(:vzero_dropin_ui_gateway) }
-#
-#   describe 'after_save' do
-#     let(:hosted_fields_gateway) { create(:vzero_hosted_fields_gateway) }
-#
-#     it 'activation should disable Hosted Fields Gateways' do
-#       subject.update_column(:active, false)
-#       expect(hosted_fields_gateway.active?).to be true
-#       subject.update(active: true)
-#       expect(hosted_fields_gateway.reload.active?).to be false
-#     end
-#
-#     it 'deactivation should not disable Hosted Fields Gateways' do
-#       subject
-#       expect(hosted_fields_gateway.active?).to be true
-#       subject.update(active: false)
-#       expect(hosted_fields_gateway.reload.active?).to be true
-#     end
-#
-#     it 'creation of activated should disable Hosted Fields Gateways' do
-#       expect(hosted_fields_gateway.active?).to be true
-#       subject
-#       expect(hosted_fields_gateway.reload.active?).to be false
-#     end
-#
-#     it 'creation of deactivated should not disable Hosted Fields Gateways' do
-#       expect(hosted_fields_gateway.active?).to be true
-#       create(:vzero_dropin_ui_gateway, active: false)
-#       expect(hosted_fields_gateway.reload.active?).to be true
-#     end
-#   end
-# end
+require 'spec_helper'
+
+describe Spree::Gateway::BraintreeVzeroDropInUI, :vcr do
+  subject { create(:vzero_dropin_ui_gateway) }
+
+  describe 'after_save' do
+    let(:hosted_fields_gateway) { create(:vzero_hosted_fields_gateway) }
+
+    it 'activation should disable Hosted Fields Gateways' do
+      subject.update_column(:active, false)
+      expect(hosted_fields_gateway).to be_active
+      subject.update(active: true)
+      expect(hosted_fields_gateway.reload).to_not be_active
+    end
+
+    it 'deactivation should not disable Hosted Fields Gateways' do
+      subject
+      expect(hosted_fields_gateway).to be_active
+      subject.update(active: false)
+      expect(hosted_fields_gateway.reload).to be_active
+    end
+
+    it 'creation of activated should disable Hosted Fields Gateways' do
+      expect(hosted_fields_gateway).to be_active
+      subject
+      expect(hosted_fields_gateway.reload).to_not be_active
+    end
+
+    it 'creation of deactivated should not disable Hosted Fields Gateways' do
+      expect(hosted_fields_gateway).to be_active
+      create(:vzero_dropin_ui_gateway, active: false)
+      expect(hosted_fields_gateway.reload).to be_active
+    end
+  end
+end

--- a/spec/models/gateway/braintree_vzero_hosted_fields_spec.rb
+++ b/spec/models/gateway/braintree_vzero_hosted_fields_spec.rb
@@ -1,35 +1,35 @@
-# require 'spec_helper'
-#
-# describe Spree::Gateway::BraintreeVzeroHostedFields, :vcr do
-#   subject { create(:vzero_hosted_fields_gateway) }
-#
-#   describe 'after_save' do
-#     let(:dropin_ui_gateway) { create(:vzero_dropin_ui_gateway) }
-#
-#     it 'activation should disable DropIn UI Gateways' do
-#       subject.update_column(:active, false)
-#       expect(dropin_ui_gateway.active?).to be true
-#       subject.update(active: true)
-#       expect(dropin_ui_gateway.reload.active?).to be false
-#     end
-#
-#     it 'deactivation should not disable DropIn UI Gateways' do
-#       subject
-#       expect(dropin_ui_gateway.active?).to be true
-#       subject.update(active: false)
-#       expect(dropin_ui_gateway.reload.active?).to be true
-#     end
-#
-#     it 'creation of activated should disable DropIn UI Gateways' do
-#       expect(dropin_ui_gateway.active?).to be true
-#       subject
-#       expect(dropin_ui_gateway.reload.active?).to be false
-#     end
-#
-#     it 'creation of deactivated should not disable DropIn UI Gateways' do
-#       expect(dropin_ui_gateway.active?).to be true
-#       create(:vzero_dropin_ui_gateway, active: false)
-#       expect(dropin_ui_gateway.reload.active?).to be true
-#     end
-#   end
-# end
+require 'spec_helper'
+
+describe Spree::Gateway::BraintreeVzeroHostedFields, :vcr do
+  subject { create(:vzero_hosted_fields_gateway) }
+
+  describe 'after_save' do
+    let(:dropin_ui_gateway) { create(:vzero_dropin_ui_gateway) }
+
+    it 'activation should disable DropIn UI Gateways' do
+      subject.update_column(:active, false)
+      expect(dropin_ui_gateway).to be_active
+      subject.update(active: true)
+      expect(dropin_ui_gateway.reload).to_not be_active
+    end
+
+    it 'deactivation should not disable DropIn UI Gateways' do
+      subject
+      expect(dropin_ui_gateway).to be_active
+      subject.update(active: false)
+      expect(dropin_ui_gateway.reload).to be_active
+    end
+
+    it 'creation of activated should disable DropIn UI Gateways' do
+      expect(dropin_ui_gateway).to be_active
+      subject
+      expect(dropin_ui_gateway.reload).to_not be_active
+    end
+
+    it 'creation of deactivated should not disable DropIn UI Gateways' do
+      expect(dropin_ui_gateway).to be_active
+      create(:vzero_dropin_ui_gateway, active: false)
+      expect(dropin_ui_gateway.reload).to be_active
+    end
+  end
+end


### PR DESCRIPTION
When Admin activates Dropin paypal method Hosted fields should be automatically disabled and vice versa.
