### PR TITLE
Fix payments settling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 
 gem 'webmock', '~> 1.24.6'
 
+gem 'test_after_commit', group: :test
+
 gemspec

--- a/app/assets/stylesheets/spree/backend/spree_braintree_vzero.css
+++ b/app/assets/stylesheets/spree/backend/spree_braintree_vzero.css
@@ -3,7 +3,3 @@ Placeholder manifest file.
 the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/backend/all.css'
 */
 
-
-.btn.action-settle { @extend .btn-success; }
-.icon-settle { @extend .icon-capture; }
-

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -1,15 +1,8 @@
 Spree::Admin::NavigationHelper.module_eval do
+  alias_method :original_link_to_with_icon, :link_to_with_icon
+
   def link_to_with_icon(icon_name, text, url, options = {})
     icon_name = 'capture' if icon_name.eql?('settle')
-    options[:class] = (options[:class].to_s + " icon-link with-tip action-#{icon_name}").strip
-    options[:class] += ' no-text' if options[:no_text]
-    options[:title] = text if options[:no_text]
-    text = options[:no_text] ? '' : content_tag(:span, text, class: 'text')
-    options.delete(:no_text)
-    if icon_name
-      icon = content_tag(:span, '', class: "icon icon-#{icon_name}")
-      text.insert(0, icon + ' ')
-    end
-    link_to(text.html_safe, url, options)
+    original_link_to_with_icon(icon_name, text, url, options)
   end
 end

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -1,0 +1,15 @@
+Spree::Admin::NavigationHelper.module_eval do
+  def link_to_with_icon(icon_name, text, url, options = {})
+    icon_name = 'capture' if icon_name.eql?('settle')
+    options[:class] = (options[:class].to_s + " icon-link with-tip action-#{icon_name}").strip
+    options[:class] += ' no-text' if options[:no_text]
+    options[:title] = text if options[:no_text]
+    text = options[:no_text] ? '' : content_tag(:span, text, class: 'text')
+    options.delete(:no_text)
+    if icon_name
+      icon = content_tag(:span, '', class: "icon icon-#{icon_name}")
+      text.insert(0, icon + ' ')
+    end
+    link_to(text.html_safe, url, options)
+  end
+end

--- a/app/models/spree/gateway/braintree_vzero_base.rb
+++ b/app/models/spree/gateway/braintree_vzero_base.rb
@@ -55,7 +55,7 @@ module Spree
 
     def settle(amount, checkout, _gateway_options)
       result = Transaction.new(provider, checkout.transaction_id).submit_for_settlement(amount / 100.0)
-      checkout.update_attribute(:state, result.transaction.status)
+      checkout.update(state: result.transaction.status)
       result
     end
 

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,19 +1,9 @@
 Spree::Payment.class_eval do
+  alias_method :original_update_order, :update_order
+
   def update_order
     # without reload order was updated with inaccurate data
     order.reload
-    if completed? || void?
-      order.updater.update_payment_total
-    end
-
-    if order.completed?
-      order.updater.update_payment_state
-      order.updater.update_shipments
-      order.updater.update_shipment_state
-    end
-
-    if self.completed? || order.completed?
-      order.persist_totals
-    end
+    original_update_order
   end
 end

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,0 +1,19 @@
+Spree::Payment.class_eval do
+  def update_order
+    # without reload order was updated with inaccurate data
+    order.reload
+    if completed? || void?
+      order.updater.update_payment_total
+    end
+
+    if order.completed?
+      order.updater.update_payment_state
+      order.updater.update_shipments
+      order.updater.update_shipment_state
+    end
+
+    if self.completed? || order.completed?
+      order.persist_totals
+    end
+  end
+end


### PR DESCRIPTION
Moves updating payment state to after_commit (after BraintreeCheckout state change).
Removes redundant order update.
Reloads order in payment update to prevent re-updating it with wrong data.
Display icon-settle as icon-capture.
Removes redundant CSS file.