### PR TITLE
We should only decorate Spree::UserSessionsController if it's defined

### DIFF
--- a/app/controllers/spree/user_sessions_controller_decorator.rb
+++ b/app/controllers/spree/user_sessions_controller_decorator.rb
@@ -1,7 +1,9 @@
-Spree::UserSessionsController.class_eval do
-  before_action :associate_user, only: :create
+if defined?(Spree::UserSessionsController)
+  Spree::UserSessionsController.class_eval do
+    before_action :associate_user, only: :create
 
-  def current_order_params
-    { currency: current_currency, guest_token: cookies.signed[:guest_token], store_id: current_store.id }
+    def current_order_params
+      { currency: current_currency, guest_token: cookies.signed[:guest_token], store_id: current_store.id }
+    end
   end
 end


### PR DESCRIPTION
Not every spree project uses `spree_auth_devise`