### PR TITLE
fixes payment_action in Spree::BraintreeCheckout to send correct mess…

### DIFF
--- a/app/models/spree/braintree_checkout.rb
+++ b/app/models/spree/braintree_checkout.rb
@@ -97,7 +97,7 @@ module Spree
       when 'completed'
         'complete'
       else
-        'fail'
+        'failure'
       end
     end
   end


### PR DESCRIPTION
…age to Spree::Payment core code ('fail' should be 'failure')