### PR TITLE
fixes has_one relationship to payment object; note current implementa…

### DIFF
--- a/app/models/spree/braintree_checkout.rb
+++ b/app/models/spree/braintree_checkout.rb
@@ -7,7 +7,7 @@ module Spree
 
     FINAL_STATES = %w(authorization_expired processor_declined gateway_rejected failed voided settled settlement_declined refunded released)
 
-    has_one :payment, foreign_key: :source_id, inverse_of: :source
+    has_one :payment, foreign_key: :source_id, as: :source
     has_one :order, through: :payment
 
     def self.create_from_params(params)


### PR DESCRIPTION
…tion is broken and will mistakenly pick-up payment records that do not haev a source_type of  Spree::BraintreeCheckout

Fixes #96.