### PR TITLE
Remove test-after-commit gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,4 @@ gem 'pg'
 gem 'mysql2'
 gem 'webmock', '~> 1.24.6'
 
-gem 'test_after_commit', group: :test
-
 gemspec


### PR DESCRIPTION
It is no longer needed with Rails 5.