### PR TITLE
Use proper namespace

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -37,7 +37,7 @@ Spree::Order.class_eval do
       if existing_card_id.present?
         credit_card = Spree::CreditCard.find existing_card_id
         if credit_card.user_id != user_id || credit_card.user_id.blank?
-          raise Core::GatewayError, Spree.t(:invalid_credit_card)
+          raise Spree::Core::GatewayError, Spree.t(:invalid_credit_card)
         end
 
         credit_card.verification_value = params[:cvc_confirm] if params[:cvc_confirm].present?

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -53,6 +53,19 @@ describe Spree::CheckoutController, :vcr, type: :controller do
         put :update, params
         expect(order.reload.payments.last.source.braintree_last_digits).to eq vaulted_payment_method.last_4
       end
+
+      context 'when user tries to steal other user card' do
+        let(:other_user) { create(:user) }
+        let!(:card) { create(:credit_card, number: '123456', user: other_user) }
+
+        it 'does not create payment' do
+          params[:order].merge!(existing_card: card.id)
+
+          expect(order.payments).to be_empty
+          put :update, params
+          expect(order.reload.payments).to be_empty
+        end
+      end
     end
 
     context 'braintree paypal express payment' do


### PR DESCRIPTION
Uses proper namespace. Fixes `NameError: uninitialized constant Core` exception.