### PR TITLE
Ruby 2.4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ end
 
 gem 'pg'
 gem 'mysql2'
-gem 'webmock', '~> 1.24.6'
+gem 'webmock', '>= 2.3.1'
 
 gemspec


### PR DESCRIPTION
Ruby 2.4 is supported from 2.3.1 version of webmock (tested with 2.3.1 and 3.0.1).