### PR TITLE
Backport token API to 3.0 branch

### DIFF
--- a/app/controllers/spree/api/braintree_client_token_controller.rb
+++ b/app/controllers/spree/api/braintree_client_token_controller.rb
@@ -1,0 +1,29 @@
+module Spree
+  module Api
+    class BraintreeClientTokenController < Spree::Api::BaseController
+      skip_before_action :authenticate_user
+
+      before_action :find_order, only: :create
+
+      def create
+        gateway = if params[:payment_method_id]
+          Spree::Gateway::BraintreeVzeroBase.find(params[:payment_method_id])
+        else
+          Spree::Gateway::BraintreeVzeroBase.where(active: true).first
+        end
+
+        render json: {
+          client_token: gateway.client_token(@order, @current_api_user),
+          payment_method_id: gateway.id
+        }
+      end
+
+      private
+
+      # We're skipping permission check for order, because it is needed only to get a currency
+      def find_order
+        @order = Spree::Order.find_by(number: params[:order_number])
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  namespace :api, defaults: { format: 'json' } do
+    resource :braintree_client_token, only: :create, controller: 'braintree_client_token'
+  end
 end

--- a/spec/controllers/spree/api/braintree_client_token_controller_spec.rb
+++ b/spec/controllers/spree/api/braintree_client_token_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Spree::Api::BraintreeClientTokenController, :vcr, type: :controller do
+  let!(:gateway) { create(:vzero_gateway, auto_capture: true) }
+  let(:order) { create(:order) }
+
+  describe 'POST #create' do
+    context 'guest checkout' do
+      it 'returns proper json data when gateway not specified' do
+        post :create, order_number: order.number
+        expect(response).to have_http_status 200
+        expect(json_response['client_token']).not_to be nil
+        expect(json_response['payment_method_id']).not_to be nil
+      end
+
+      it 'returns proper json data when gateway specified' do
+        post :create, payment_method_id: gateway.id, order_number: order.number
+        expect(response).to have_http_status 200
+        expect(json_response['client_token']).not_to be nil
+        expect(json_response['payment_method_id']).to eq gateway.id
+      end
+    end
+
+    context 'user checkout' do
+      let!(:user) { create(:user) }
+      before { user.generate_spree_api_key! }
+
+      it 'returns proper json data when gateway not specified' do
+        post :create, order_number: order.number, token: user.spree_api_key
+        expect(response).to have_http_status 200
+        expect(json_response['client_token']).not_to be nil
+        expect(json_response['payment_method_id']).not_to be nil
+      end
+
+      it 'returns proper json data when gateway specified' do
+        post :create, payment_method_id: gateway.id, token: user.spree_api_key, order_number: order.number
+        expect(response).to have_http_status 200
+        expect(json_response['client_token']).not_to be nil
+        expect(json_response['payment_method_id']).to eq gateway.id
+      end
+    end
+  end
+
+  private
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/guest_checkout/returns_proper_json_data_when_gateway_not_specified.yml
+++ b/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/guest_checkout/returns_proper_json_data_when_gateway_not_specified.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://5ffsvj9qxt38xptf:50ea069d312d35fbf779a66b6c86b897@api.sandbox.braintreegateway.com/merchants/zt9ssvxzppgzdjmn/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.64.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Jul 2016 15:37:42 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - vzw4dwqpkk82wnfg
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"82a8e303ef6764cf801a1f95e1bd6a17"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a904cfd7-33b5-4a41-9d28-afef263d0726
+      X-Runtime:
+      - '0.127775'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEbVmFcAA8RV23KjOBB9n69I5X12QJjUUJVkKo4DmDLygM1FekMSCRcJ
+        s/GFy9dP42Q3SW328rYPLlchdffp0+e0rn/0Sl6c8ud9uWtuLvXftMuLvOE7
+        UTZPN5fR1v76/fLH7ZdrLsu8OXw97Oq8uf1ycXF9yuQxv80HD9HUG7PEOi6r
+        3bC69wqRhjtmeG2ubG36Hip5pCgeuOu1rAnKdbmc4QUt8NbvSVXPcIJrv4qr
+        9eIJ4STQ1os701cPHV4UFVXRiBOv8tFytl48IOr43TqJCzxiSau7joxh4SdY
+        +dtQPjp4oImt0SR8JGlg+dVdj0utw4M2YD3o8XY34nGn+eVsxNu7Do8PM7zl
+        z/7irvPtXof/AStdcoV3JDG1FMn6Z9pq6xSPoimuuDtvchX+zhKTC4j3K9qJ
+        xNtnCX7MUGz+3MaKNhhllexzNxjXbtEJh5TAScWQqbJExFx10L+3E27Y8XF3
+        WiG7yzbmCPVqoqzZSnkDSeRRuJ6kiSiEExskrY8EWYd1FWj+YB2A7ypzbLjj
+        n/ImMLmBUe62HXfEFXXaAyutijlSsmbiYd6uDNKvED4xRVtqxANJw5ah2RkX
+        5NkzJ57mMy6rli0VRqL0BJxBPG25so4siY/ifnm1bHDBVFgy4+mlp5cac+7I
+        /6WvZdmVBGZD03CMU28P+iszN9S461+tBquAeAm5jqTxigzmyVUsKQJ9pKLI
+        NybMRCv/0Otn8dP3VUMlU/pp9db7v+Zjyt7nwDEx/HLd7Evx19yvfQQH4Kdg
+        rgSf4PE/1vgbbjwLamvZxG8UbmmCdYi1AUsJ861hthpvYgl3OpLKjiT9P5x1
+        Z9zUkSN3+iKPAGMSTfM9smEOGHS4Y5pn/lHfUsC5SSZfe/M4FZKMRUdq8RhH
+        lMRaHwinkKHyktig96y2wo1j1yyljwxFM6q6Ltgu+yihzXb0Ch7pmy3CKtQL
+        d6PJDV7YQy7xNnHDZyrbODD4GLuege+X+2UzH7KUFsT4qL91+f1E06Jg6XxP
+        Xznj7t00G53DHgoSAXsiPky4P8x9Mek2npFE75gTnbW5MsITH6CWAmwo/kzn
+        I3zX+GCWXNmw38IpdwMekwLZ5kqB7zZT/Os9PR7Y5CVVaMKdjxNWggpJ0OEk
+        0uDIHduE3/4tLgQPxpV4eFdfmTpzuikneNcyNhN2yAne0ummK6EvlKUe+F2f
+        vLJmmgk+ECeu9hBLQW9YfupvZSmq+pap6MwVnENcKOnD204ErSjQzjjVea/R
+        4KMODuBLbfLzq87Hs1aUBLzwFmh2M8Wc67r4vQ7/zA1nA/BSTPuFwO4Sb7kb
+        0swr8BTwbFb5mSPQegP9KGxuUnwKkFXTDfRTi/vo/uwL0IA8EpgBjeIjgZ1N
+        p1xvXLztngdZT3r43GOT5l72wXSHIaqWjXZz/e3lLfxy/e3jK/kLAAD//wMA
+        cXmQAVwHAAA=
+    http_version:
+  recorded_at: Wed, 27 Jul 2016 15:37:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/guest_checkout/returns_proper_json_data_when_gateway_specified.yml
+++ b/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/guest_checkout/returns_proper_json_data_when_gateway_specified.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://5ffsvj9qxt38xptf:50ea069d312d35fbf779a66b6c86b897@api.sandbox.braintreegateway.com/merchants/zt9ssvxzppgzdjmn/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.64.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Jul 2016 15:37:41 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - vzw4dwqpkk82wnfg
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"e5f0587afcfdbf30055cc5224b63d6cc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c1f2f584-8e46-47cb-83d4-8cee5cc65f58
+      X-Runtime:
+      - '0.124552'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEXVmFcAA8RV2XKcOBR9z1e4/J4JCOMKVXZSbjts1ajDjvSGEDaLRDPp
+        hYavz1XbM45rPMvbPFCiJN3t3HOubr6epLg41j927Xa4vdR/0y4v6qHa8nZ4
+        ur1ME/vj58uvXz7cVKKth/3H/bavhy8fLi5ujqU41F/q2Ue08Jcytw5et53X
+        937Di2jLDH+spa2p/UiKA0XZXLn+yIaw3bTegp1QD5YAwYpw5+lBcmcEKGvJ
+        wvtgeVpoEp5wRwzSNV0gU5M+qP+nGSe9SZCnkY52wXJ3RRK/CaSn0eRpenTw
+        THNbo3n0SIrQCrq7E261Cc/ajHXwl2wXvGy1IL7SgodAx8kdfN6P4OFuCuyT
+        DuuMpS4qibckN7UCif57MWqbAi98aK4rdzXUMvqd5WbFE7Dp6MRzf1fm+LFE
+        mfk9ySQdMCo7cardcNm4zcQd0gImHUOmLHOeVXKC+v0td6OpWrbHNbKnMjYX
+        iNcTaV2tpT+TXBy46wua84Y7mUGK/kCQtd90oRbM1h7w7krHhjvBsR5CszIw
+        qt1xqhx+TZ1xz1qrY44QbFA4rMa1QU5rhI9M0pEa2UyKaGTo6pwX+NkxJ1P9
+        WbxuZJ7EiLc+hzOwp2MlrQPLswO/9669ATdMRi0znp5reo6xqhzxv9TltVNL
+        oDe0iJas8HfAv7Z0I61yg+v1bDVgL8DXgQx+U0I/K5kJioAfBW/q2ISeaO0f
+        fH3PXu2vByqY1I/r19r/1R+T9q4GjIkRtJth1/K/+n6pI9wDPg1zBegEL/8x
+        xt9g41sQWysVvmmU0BzrYGtDLi30t4featWQCbgzkUJMJD/9w9l0zps6Yqmc
+        U1OnkGOeqv4e2LyCHHS4Y5pn/NFppJBnnCtd+6us4IIszUR6/pillGTaKeRO
+        IyLp55lB71lvRbFj96ygjwylV1ROU5h4pzSnQ7L4TZXqcYKwjPTGjTUR4wd7
+        rgVOcjf6QcWYhUa1ZK5v4Htv5w2ruSxoQ4y3/Nu0n4+0aBpWrHb0BbPKvVO9
+        0SuYQ2HOYU5ke5X3m74/KN5mVyTXJ+akZ26ujehYzRBLQm4oe4/nC+xr1Wy2
+        lbRhvkXK9wAaExzZ5lqC7mJl/3JPz2amtCQbjburReVKUCMI2h95ER4qxzbh
+        273aRaDBrOPffokvTZ05k/IJ2rWMWOUOPkFbOo2nFupCZeGD3nWllQ3TTNAB
+        P1ZyB7YU+IbFu/qWlqTyNDKZnrGCc7CLBP32OhOBKxK4s6g4v3I0fMuDPehS
+        U3p+4fly5ooUkC+8BZo9KJtzXBf/ysM/fcPZDLg0ar4QmF381fdAhlUHmgKc
+        za4+YwRcH6Aeic24wMcQWT2NoZ6e36f3Z10AB8SBQA9omh0IzGyqfL1i8Tp7
+        vole8eF9jSnOPc8DdYchKr1Bu7359PwWfrj59PaV/AkAAP//AwAXw2FJXAcA
+        AA==
+    http_version:
+  recorded_at: Wed, 27 Jul 2016 15:37:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/user_checkout/returns_proper_json_data_when_gateway_not_specified.yml
+++ b/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/user_checkout/returns_proper_json_data_when_gateway_not_specified.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://5ffsvj9qxt38xptf:50ea069d312d35fbf779a66b6c86b897@api.sandbox.braintreegateway.com/merchants/zt9ssvxzppgzdjmn/customers/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.64.0
+      X-Apiversion:
+      - '4'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Jul 2016 15:37:43 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - vzw4dwqpkk82wnfg
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"09159c0a7bf6b5a4da8c86946ec55ef9"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2a186cc2-3fa6-46bf-9a03-87dcf6fdd883
+      X-Runtime:
+      - '0.353876'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEfVmFcAA+ydW3OjNhTH3/dTeNxnwsXYxozDNt1Op+3s9GWTPvRlR4Cw
+        iUGwIN/y6SuBuTl2QsSE2LNnH7LW0dEJQT/9rRti/nkXBoMNTlI/IrdD9UYZ
+        DjBxItcni9vhw/0fkjH8bH2aO+uURiFOrE+Dwdx3LXUus588wYzOEhEqsfQT
+        naXpZvcUx4sn9zEkc7mey709P0mpRFCILZTa7nIu1yzcIUBFynZT9DiXKwPP
+        dqIwRmQ/IH5wO6TJGg/lzI5D5AdWGicY/4p3KIwDfMN853KewV3iZUTws4Ie
+        2j2zbbGd+vS5r5NgRLErITqg+xjfDl2WpH6Ih5amqBNJmUqqfq9q5sgwlcl/
+        c7kqkJVfx+7bylcF8t+fVYLk+Thw0/KSXJ9KDkrc9BAUJQnaD3luMz+3MJvt
+        E0tX+b+5zD8Xdu4k8RjWv36K2NWX6brHMgpcnGQ1cnyDcp8o5JXuo8B6ICsS
+        bRkFNVvltiY02UuRJ/lpukbEwXX/55llwdcrQZvcq2NzpJr69Fkl5DEONEs5
+        yfXkM5cgchBljcN6+FbzLK2Fv4ttn1Z/QZ6sMj20DooLtqMowIgMLQ8FKea+
+        WW7lvU5YtUgJXqwDfuW1qMc5RRG8i/0kuyApjAhdWqrG0D82nvDeY5Tw+zZt
+        uGfWhjd2z1z8Ibf0XmIU0CUDpVadNVvh5odogaV1ElhLSuPUlGWUppimN3aC
+        fFb3GC/YH7hFe96K5RjtQ0zo9xDTZeR+D6JFJG8YozcxWXzGZOMnEeEOtyki
+        rh3tmDiV8cvfyEBioibZiKyqS2tYC9dMcnQrbyGHRJHHLiWJghrbhaF0SHCM
+        /FqlFYbCIV3bqZP4Mb/TzTZbNSIarTCxZtsnz03mcp4q8tbE/7HGElmHdoYs
+        +7t9JgmJ5Uz1yXg0U7CBXEN3sDK1DU2feYYzdpAzYkScLVrGfl2hmo2rqVBZ
+        jA0mYSSl7uoMMWV+rUTCLiNvUCfvSNaImzr28yrbyNQUU9VA2UDZrlbZbLKy
+        0/ACla1qXKBs/Srb+F6Z8a8VdQzKBsp2tco2IdqjPrlAZVPMsW4qM1C23pVN
+        48qmsiG9AcoGyna1yrZw91Nve2nK1mhcoGy9K5thsj7zWAdlA2W7WmVz7GR5
+        kcpmmJpqKiNQtt6VTb1XpqausgEpKBso29Uq29TztJV9acrWaFygbP0qm3Kv
+        6rzPNhqBsoGyXa2yLdzQubwVhEbjAmXrW9lYh5l9rWjPt96AsoGyXYuyud7m
+        MVxcoLIppqLAro8PULaXNhVekrLxO3cZwjYBYbs8YVske8O5tC7bSxtuexO2
+        hiHNLMh1E8wYOrmr95BZweBaT0/Fjuy2ilDbeE3w9jv/cLwbu8Ins/we4aP9
+        2IVC8j3Z1pf8/0weM0OJCG8AVCquWlUGX6MNDvaDb1nGXD5yqJoqxcTl1XHI
+        +CdK6HKLU8ob6lFeeblMyQKf7q0/cULciBFbWgoXJjhc6u6+zuXDx5L2KKUo
+        kJzIxdZorChjxnvNdCz23CihIF4iLZfTE/bzZUaszN2pQqPThRjnjCzHMnTl
+        qFSRc1wsq6YH4jOk2b1mZKeDyBvcZc6oitGszRbfRzPe01Y0UzmzV6dNuytj
+        nGp3c7lRraeA588OCAP/d7QkADvA3g52NqbX2bB+1gX2WgwB2OMVwA6w9wb7
+        1Bx3UvZaDAHYnwjADrC/P+z5hOFYNbUzG/PazYvUYgjATvcAO8DeC+yqYo7G
+        Z+eQWk8CFjEEYA9/AOwAe4+wq0p32LMYArB7HszIAPDXCPypbTktgE+g3w6w
+        9wS7aiqqOT5zvENL2KsYArDrG4AdYO8TdvHpx2YMAdj3M+jKAPC9Aq+ZSreu
+        TB5DsCszskHdAfa+YNd11u3uCHsRQwD2iQbqDsD3DXzXvjuPITjnvtdB3QH2
+        PmHv2ncvYoispoK6A/A9Aq+ZI83UO62oHmIIAq8loO4Ae4+wj8+cxfgW2Men
+        jpxrM+cOA1WAvVfYzzw2/CbYTz0d2WZFdfuRsJ98OuiYc200+M0PAp8s3kz6
+        XUxvBr+obTj/smSVuYjOc/7Xy5xPlIlqAOcij8d3fgq4Bec72CYDot4b7PzA
+        226TMVUMkQ2QMD4F4PsGXuu2tpTHEFxbeuyymArqDrC/GfZu49MqhkiXHWAH
+        2HuC3TB1xdTPHNjXEvYqhsiesC6TMdCVAeCFgO82UM1j6GLAL2CgCrD3Cnu3
+        bTJVDAHYVx86+wiw/2SwG133hFUxBGBfPgLsAHufsHebgqxiCMC+NaDfDsD3
+        DLzebQoyjyE4UPViWEiFhdT35fy1Nyh0Pii+BeezHXAOnL8v56+9A6n1q16K
+        GAKcGx96iAxw/tNwztf5u3JexBDZ2gucA+e9cH547VYnzs+8uqsF5w4FzoHz
+        d+f8xbfSdn75ZptZxhBmGWHSpQfYs5fL64c9W4KwN2KInOHbZZYRYAfY3wx7
+        h31fjRgiMy8LmFIH4PsGvkOXvYwhODSdwDm+AHt/sOtdTmhvxhCZb+xytCnA
+        DrC/GfYOuwMaMQRg/9FlEQm6MgD8hwH/6qxMmcAsWbFsffofAAD//wMA0T2o
+        rheaAAA=
+    http_version:
+  recorded_at: Wed, 27 Jul 2016 15:37:43 GMT
+- request:
+    method: post
+    uri: https://5ffsvj9qxt38xptf:50ea069d312d35fbf779a66b6c86b897@api.sandbox.braintreegateway.com/merchants/zt9ssvxzppgzdjmn/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <customer-id type="integer">1</customer-id>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.64.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Jul 2016 15:37:44 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - vzw4dwqpkk82wnfg
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"f32b73e69ec5027db9bd65f2b4258874"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b5e4e4e7-77e4-496f-98ca-6b28ee06b15d
+      X-Runtime:
+      - '0.048848'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEjVmFcAA8RVW2+jOBR+n19R9X12wIRukTodNRcgKDgTGjD2W7CZ4WKT
+        bBPC5dfvcdrttFL38rZCyJLtc/u+7xzffeuVvDrnT8dy33y9Nn8zrq/yhu9F
+        2fz8eh1v3c+319/uP91xWebN6fNpX+fN/aerq7vzTrb5fT4EiKXBuCNOu6z2
+        w2oWFCKN9pkVHHLlGno/UrJlKBm4HxyyZlOuy2VHt3WPtwt7vd10lAQ1VrGN
+        t6KgaGNSshjWJDTCeVDhajOG8NFxM4SKWphselwVklZRrfdoRSfreTgwElo/
+        PAyrazAS/aDpxgmrhx6XRocHY8Am2G33Ix73Bp5NzPV2MQnntfb8FM4futDt
+        TVgHrLDJreickWRIkay/b10utnBesRPUWe08txWuc2Bz80bM5cgtNsmbaces
+        Q71TZpv6cRfOl4j7SZl5skrRSeZbw2SKjULtbZ4WRjgWE+5Hall2JUVOy5Rs
+        kjQ4An7lzo8M7oc3q8EpuFe3HLkt84JzPrNLrlzAL4Iak4amkRTItVcKn7Mt
+        1DQPLzlTVBRwZ1xZB2Od4lE0xQ33p02uoj8yMjlT1B8YsY0Uud3u0UHho1Nl
+        yFY7Ikz+wtdzXuDH62WmhOTD8oYMQSUaWqaPXQn2aJcG50yZ8pnPYKTErqly
+        Js+2zzE26fTw/9S1PC6VO3KUGNxMhmy2vFmqwhD+dFyXt2cK9iwFXyoYKJGt
+        8APJiCiEl1g0rVvg5HSpI02MnfuRPezPbATxTtlgv9b+r/6IXWS+BIzxuKwO
+        vy+bD3y/1LEibktJbwvQEP+PMf4Gm/IHcCa8QuO7iFFSiTSQEeRCVS8ZxAdf
+        JoM73HNt+I//dHbJW0UHbk2PNJVrSkyp+c3U7U+dA9xp8wv++LgjSSsWstbn
+        mySxoEcn3Av81Ew84oow9qM9i1mZAOMbZX+P46JgnolS5Mi1x47hYjGEiauY
+        cTvQ1MVx7VSsFjQyTkFcbXreHLaxWRg7xHZJjK3QjAYxbkqYQR1XElGC7Xf6
+        m+/PK5RMIOcu8+IXzKad5kakWPLabbhKZKbzfsf7g9atzD0X6uvlRZuPjpFZ
+        oY4FOsHyQ51bWAo/bGkTFDvgVPtmCOZTKor80Ya+M7T9yz2ccNXpXtoLP+r4
+        qHPFe0bwU2YlxqqZFnk6LbLZq10NPSipFc1+xT+0gvRH7RN69yyMS+7lGnpL
+        kBg4gbqUHKDfT1pjW+WsoQ8smNVPYKtAbyP7uL/PML+AT1tesIJzsNNzFr/O
+        RMCKKffIkY7zRqPxex1kxB1Bs8NfOg8HrRV4F7z+ALNmyiytax03Gt/q8Jdv
+        U3KF91TPF4IrwObVN0NBRy14Z6BOatUaI6110L1d5bEcMwOfmRfrevyNfLj0
+        BWgA4gIHKHEz5cLMTuq3WLyZPYHOY9l83GMQ62UeaM04ipWBc/fl+Y38dPfl
+        /ev5JwAAAP//AwAPFQ6RdAcAAA==
+    http_version:
+  recorded_at: Wed, 27 Jul 2016 15:37:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/user_checkout/returns_proper_json_data_when_gateway_specified.yml
+++ b/spec/vcr/Spree_Api_BraintreeClientTokenController/POST_create/user_checkout/returns_proper_json_data_when_gateway_specified.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://5ffsvj9qxt38xptf:50ea069d312d35fbf779a66b6c86b897@api.sandbox.braintreegateway.com/merchants/zt9ssvxzppgzdjmn/customers/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.64.0
+      X-Apiversion:
+      - '4'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Jul 2016 15:37:45 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - vzw4dwqpkk82wnfg
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"f67e82f8ea926a55e3dd8646d8911e09"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1c5e7e1a-bc52-437f-b5d9-e003ee8dc4f3
+      X-Runtime:
+      - '0.286375'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEnVmFcAA+ydW3OjNhTH3/dTeNxnwsXYxozDNt1Op+3s9GWTPvRlR4Cw
+        iUGwIN/y6SuBuTl2QsSE2LNnH7LW0dEJQT/9rRti/nkXBoMNTlI/IrdD9UYZ
+        DjBxItcni9vhw/0fkjH8bH2aO+uURiFOrE+Dwdx3LXUus588wYzOEhEqsfQT
+        naXpZvcUx4sn9zEkc7mey709P0mpRFCILZTa7nIu1yzcIUBFynZT9DiXKwPP
+        dqIwRmQ/IH5wO6TJGg/lzI5D5AdWGicY/4p3KIwDfMN853KewV3iZUTws4Ie
+        2j2zbbGd+vS5r5NgRLErITqg+xjfDl2WpH6Ih5amqBNJmUqqfq9q5sgwlcl/
+        c7kqkJVfx+7bylcF8t+fVYLk+Thw0/KSXJ9KDkrc9BAUJQnaD3luMz+3MJvt
+        E0tX+b+5zD8Xdu4k8RjWv36K2NWX6brHMgpcnGQ1cnyDcp8o5JXuo8B6ICsS
+        bRkFNVvltiY02UuRJ/lpukbEwXX/55llwdcrQZvcq2NzpJr69Fkl5DEONEs5
+        yfXkM5cgchBljcN6+FbzLK2Fv4ttn1Z/QZ6sMj20DooLtqMowIgMLQ8FKea+
+        WW7lvU5YtUgJXqwDfuW1qMc5RRG8i/0kuyApjAhdWqrG0D82nvDeY5Tw+zZt
+        uGfWhjd2z1z8Ibf0XmIU0CUDpVadNVvh5odogaV1ElhLSuPUlGWUppimN3aC
+        fFb3GC/YH7hFe96K5RjtQ0zo9xDTZeR+D6JFJG8YozcxWXzGZOMnEeEOtyki
+        rh3tmDiV8cvfyEBioibZiKyqS2tYC9dMcnQrbyGHRJHHLiWJghrbhaF0SHCM
+        /FqlFYbCIV3bqZP4Mb/TzTZbNSIarTCxZtsnz03mcp4q8tbE/7HGElmHdoYs
+        +7t9JgmJ5Uz1yXg0U7CBXEN3sDK1DU2feYYzdpAzYkScLVrGfl2hmo2rqVBZ
+        jA0mYSSl7uoMMWV+rUTCLiNvUCfvSNaImzr28yrbyNQUU9VA2UDZrlbZbLKy
+        0/ACla1qXKBs/Srb+F6Z8a8VdQzKBsp2tco2IdqjPrlAZVPMsW4qM1C23pVN
+        48qmsiG9AcoGyna1yrZw91Nve2nK1mhcoGy9K5thsj7zWAdlA2W7WmVz7GR5
+        kcpmmJpqKiNQtt6VTb1XpqausgEpKBso29Uq29TztJV9acrWaFygbP0qm3Kv
+        6rzPNhqBsoGyXa2yLdzQubwVhEbjAmXrW9lYh5l9rWjPt96AsoGyXYuyud7m
+        MVxcoLIppqLAro8PULaXNhVekrLxO3cZwjYBYbs8YVske8O5tC7bSxtuexO2
+        hiHNLMh1E8wYOrmr95BZweBaT0/Fjuy2ilDbeE3w9jv/cLwbu8Ins/we4aP9
+        2IVC8j3Z1pf8/0weM0OJCG8AVCquWlUGX6MNDvaDb1nGXD5yqJoqxcTl1XHI
+        +CdK6HKLU8ob6lFeeblMyQKf7q0/cULciBFbWgoXJjhc6u6+zuXDx5L2KKUo
+        kJzIxdZorChjxnvNdCz23CihIF4iLZfTE/bzZUaszN2pQqPThRjnjCzHMnTl
+        qFSRc1wsq6YH4jOk2b1mZKeDyBvcZc6oitGszRbfRzPe01Y0UzmzV6dNuytj
+        nGp3c7lRraeA588OCAP/d7QkADvA3g52NqbX2bB+1gX2WgwB2OMVwA6w9wb7
+        1Bx3UvZaDAHYnwjADrC/P+z5hOFYNbUzG/PazYvUYgjATvcAO8DeC+yqYo7G
+        Z+eQWk8CFjEEYA9/AOwAe4+wq0p32LMYArB7HszIAPDXCPypbTktgE+g3w6w
+        9wS7aiqqOT5zvENL2KsYArDrG4AdYO8TdvHpx2YMAdj3M+jKAPC9Aq+ZSreu
+        TB5DsCszskHdAfa+YNd11u3uCHsRQwD2iQbqDsD3DXzXvjuPITjnvtdB3QH2
+        PmHv2ncvYoispoK6A/A9Aq+ZI83UO62oHmIIAq8loO4Ae4+wj8+cxfgW2Men
+        jpxrM+cOA1WAvVfYzzw2/CbYTz0d2WZFdfuRsJ98OuiYc200+M0PAp8s3kz6
+        XUxvBr+obTj/smSVuYjOc/7Xy5xPlIlqAOcij8d3fgq4Bec72CYDot4b7PzA
+        226TMVUMkQ2QMD4F4PsGXuu2tpTHEFxbeuyymArqDrC/GfZu49MqhkiXHWAH
+        2HuC3TB1xdTPHNjXEvYqhsiesC6TMdCVAeCFgO82UM1j6GLAL2CgCrD3Cnu3
+        bTJVDAHYVx86+wiw/2SwG133hFUxBGBfPgLsAHufsHebgqxiCMC+NaDfDsD3
+        DLzebQoyjyE4UPViWEiFhdT35fy1Nyh0Pii+BeezHXAOnL8v56+9A6n1q16K
+        GAKcGx96iAxw/tNwztf5u3JexBDZ2gucA+e9cH547VYnzs+8uqsF5w4FzoHz
+        d+f8xbfSdn75ZptZxhBmGWHSpQfYs5fL64c9W4KwN2KInOHbZZYRYAfY3wx7
+        h31fjRgiMy8LmFIH4PsGvkOXvYwhODSdwDm+AHt/sOtdTmhvxhCZb+xytCnA
+        DrC/GfYOuwMaMQRg/9FlEQm6MgD8hwH/6qxMmcAsWbFsffofAAD//wMA0T2o
+        rheaAAA=
+    http_version:
+  recorded_at: Wed, 27 Jul 2016 15:37:45 GMT
+- request:
+    method: post
+    uri: https://5ffsvj9qxt38xptf:50ea069d312d35fbf779a66b6c86b897@api.sandbox.braintreegateway.com/merchants/zt9ssvxzppgzdjmn/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <customer-id type="integer">1</customer-id>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.64.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Jul 2016 15:37:46 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - vzw4dwqpkk82wnfg
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"62ceea689040985e124769b45cdaa56e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0426bd29-6706-46b5-aade-10ef202a1cfe
+      X-Runtime:
+      - '0.081845'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAErVmFcAA8RVy3KjOBTd91eksu9pECYTqtLdFccBTBm5TQAh7UCiw0MC
+        T2zM4+vn4mTSSVXmsZsFG6T7Oufco5vvg5IXp/zpULbN10v9N+3yIm94K8rm
+        8etlFNqfry+/f/t0w2WZN8fPx7bOm2+fLi5uTqns8m/56CGWeFNKrG5dtePm
+        zitEErSZ4e1zZWvz/0DJjqF45K63z5pduS09RatbDat73V+xApO48sPHEYeP
+        Olvdm7hi0l/RyV8JRUlkbEOv3jpY0RBLn9jl1tktMMElnijaEk+ycN37jr/4
+        6eCREVtjJPhJk53lV7cDLrUej9qI9d2Aw3bCU6vhcoHw5EP+9cJf+U/+6rb3
+        7QF6uR2xwjo3glNG4jFBsv4R2lyEcF6xI8xZpY7dCdvas5V+JVZy4gZb5M2y
+        Z8a+TpXeJW7UQ17E3bjMHFkl6CjzUNOZYpNQrcmTQvOnYsHdQK3LvqTI6piS
+        TZx4B8CvTN1A465/tRmtgjt1x5HdMcc75XdmyZUN+AUwY9zQJJAC2eZG4VMW
+        wkwr/9wzRUUBd6aNsde2CZ5EU1xxd9nkKvgjI4sTRcOeEVNLkN2nDxbyH6wq
+        Q6ZKidD5C1/PfUEeZ5CZEpKP6ysyepVoaJk89CXEozTxTpnS5QufEyVmTZW1
+        eI59rrFLlvv/Z671Ya3siaNY43o8Znfrq7UqNOEup215faIQzxLIpbyREtkJ
+        FzRERCGc2KBJ3QEnx/McSayl9kfx8P/ORFDvmI3m6+z/mo+YReZKwBhP62r/
+        +7r5IPfLHBtid5QMpgAN8f9Y42+wKX8CZ8IpZnzvIxRXIvFkAL1QNUgG9SGX
+        zuAOd2wTvsM/nZ37VsGeG8sDTeSWEl3O/Gbq+nHuAe50+Rl/fEhJ3Il7Wc/n
+        uzg2GPEX3PHcRI8dYgs/coOWRayMgfGdMn9EUVEwR0cJsuTWYQf//n70Y1sx
+        7XqkiY2j2qpYLWigHb2o2g282YeRXmgpYmkcYcPXg1FMuxI8qOdKIkqw+U5/
+        q/a0QfECeu4zJ3rBbNnP3IgES17bDVexzOa+3/F+O+tW5o4N8w3yrM0HS8sM
+        f64FOsHyQ50bWArX72jjFSlwOudmCPwpEUX+YMLeaXP8yz0cc9XPu9QKN+j5
+        NPeKW0bwU2bE2qZZFnmyLLK717gadlBSI7j7VX/fCTIc5pywuyehnXsvt7Bb
+        gkTACcyl5Aj7fpw1FiprC3tggFc/QSx47TCxj/f7BP4FfJryjBWcQ9zss/jV
+        EwErpuwDR3OdNxqN3usgI/YEmh3/0rk/zlqBd8EZ9uA1S2bMup7rBtNbHf7K
+        rUuucEtnfyG4AmxeczPk9dSAdwbmpEY9YzRrHXRvVnkkp0zDJ+ZE8zzuTt6e
+        9wI0AHWBAxTbmbLBs+P6LRZvvMeb+1g3H+8Y1Hrxg1kzlmKlZ918eX4jP918
+        ef96/gkAAP//AwBwIIdPdAcAAA==
+    http_version:
+  recorded_at: Wed, 27 Jul 2016 15:37:46 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This is just a copy/paste job from @jafffmen work on #63. The only changes made were:

* All `v1` prefixes have been removed since that did not happen until the 3.1 version.
* Finding the active braintree gateway doesn't use the `active` scope since that wasn't added to Spree::PaymentMethod until 3.1. Instead a simple `where(active: true)` is used.