### PR TITLE
fix 'unable to convert unpermitted parameters to hash' when guest use…

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -13,7 +13,7 @@ Spree::CheckoutController.class_eval do
     return unless Spree::Auth::Config[:registration_step]
     return if spree_current_user || current_order.email
     store_location
-    redirect_to spree.checkout_registration_path(params)
+    redirect_to spree.checkout_registration_path
   end
 
   def update_source_data


### PR DESCRIPTION
When guest user to checkout, raise those error:

ActionController::UnfilteredParameters (unable to convert unpermitted parameters to hash):
  
actionpack (5.1.2) lib/action_controller/metal/strong_parameters.rb:258:in `to_h'
actionpack (5.1.2) lib/action_controller/metal/strong_parameters.rb:302:in `to_query'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:646:in `block in <class:Generator>'
actionpack (5.1.2) lib/action_dispatch/journey/formatter.rb:77:in `block in extract_parameterized_parts'
actionpack (5.1.2) lib/action_dispatch/journey/formatter.rb:76:in `each'
actionpack (5.1.2) lib/action_dispatch/journey/formatter.rb:76:in `extract_parameterized_parts'
actionpack (5.1.2) lib/action_dispatch/journey/formatter.rb:21:in `block in generate'
actionpack (5.1.2) lib/action_dispatch/journey/formatter.rb:91:in `match_route'
actionpack (5.1.2) lib/action_dispatch/journey/formatter.rb:20:in `generate'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:736:in `generate'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:767:in `generate'
routing-filter (0.6.1) lib/routing_filter/adapters/rails.rb:30:in `block in generate'
routing-filter (0.6.1) lib/routing_filter/filters/locale.rb:70:in `around_generate'
routing-filter (0.6.1) lib/routing_filter/filter.rb:11:in `run'
routing-filter (0.6.1) lib/routing_filter/chain.rb:15:in `run'
routing-filter (0.6.1) lib/routing_filter/adapters/rails.rb:29:in `generate'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:814:in `url_for'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:267:in `call'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:208:in `call'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:323:in `block (2 levels) in define_url_helper'
actionpack (5.1.2) lib/action_dispatch/routing/routes_proxy.rb:32:in `checkout_registration_path'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/spree_braintree_vzero-0ccaae363837/app/controllers/spree/checkout_controller_decorator.rb:16:in `check_registration'
activesupport (5.1.2) lib/active_support/callbacks.rb:413:in `block in make_lambda'
activesupport (5.1.2) lib/active_support/callbacks.rb:178:in `block (2 levels) in halting_and_conditional'
actionpack (5.1.2) lib/abstract_controller/callbacks.rb:12:in `block (2 levels) in <module:Callbacks>'
activesupport (5.1.2) lib/active_support/callbacks.rb:179:in `block in halting_and_conditional'
activesupport (5.1.2) lib/active_support/callbacks.rb:507:in `block in invoke_before'
activesupport (5.1.2) lib/active_support/callbacks.rb:507:in `each'
activesupport (5.1.2) lib/active_support/callbacks.rb:507:in `invoke_before'
activesupport (5.1.2) lib/active_support/callbacks.rb:130:in `run_callbacks'
actionpack (5.1.2) lib/abstract_controller/callbacks.rb:19:in `process_action'
actionpack (5.1.2) lib/action_controller/metal/rescue.rb:20:in `process_action'
actionpack (5.1.2) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
activesupport (5.1.2) lib/active_support/notifications.rb:166:in `block in instrument'
activesupport (5.1.2) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (5.1.2) lib/active_support/notifications.rb:166:in `instrument'
actionpack (5.1.2) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
actionpack (5.1.2) lib/action_controller/metal/params_wrapper.rb:252:in `process_action'
activerecord (5.1.2) lib/active_record/railties/controller_runtime.rb:22:in `process_action'
actionpack (5.1.2) lib/abstract_controller/base.rb:124:in `process'
actionview (5.1.2) lib/action_view/rendering.rb:30:in `process'
actionpack (5.1.2) lib/action_controller/metal.rb:189:in `dispatch'
actionpack (5.1.2) lib/action_controller/metal.rb:253:in `dispatch'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:49:in `dispatch'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:31:in `serve'
actionpack (5.1.2) lib/action_dispatch/journey/router.rb:46:in `block in serve'
actionpack (5.1.2) lib/action_dispatch/journey/router.rb:33:in `each'
actionpack (5.1.2) lib/action_dispatch/journey/router.rb:33:in `serve'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:832:in `call'
railties (5.1.2) lib/rails/engine.rb:522:in `call'
railties (5.1.2) lib/rails/railtie.rb:185:in `public_send'
railties (5.1.2) lib/rails/railtie.rb:185:in `method_missing'
actionpack (5.1.2) lib/action_dispatch/routing/mapper.rb:17:in `block in <class:Constraints>'
actionpack (5.1.2) lib/action_dispatch/routing/mapper.rb:46:in `serve'
actionpack (5.1.2) lib/action_dispatch/journey/router.rb:46:in `block in serve'
actionpack (5.1.2) lib/action_dispatch/journey/router.rb:33:in `each'
actionpack (5.1.2) lib/action_dispatch/journey/router.rb:33:in `serve'
actionpack (5.1.2) lib/action_dispatch/routing/route_set.rb:832:in `call'
versioncake (3.3.0) lib/versioncake/rack/middleware.rb:17:in `call'
warden (1.2.7) lib/warden/manager.rb:36:in `block in call'
warden (1.2.7) lib/warden/manager.rb:35:in `catch'
warden (1.2.7) lib/warden/manager.rb:35:in `call'
rack (2.0.3) lib/rack/etag.rb:25:in `call'
rack (2.0.3) lib/rack/conditional_get.rb:25:in `call'
rack (2.0.3) lib/rack/head.rb:12:in `call'
rack (2.0.3) lib/rack/session/abstract/id.rb:232:in `context'
rack (2.0.3) lib/rack/session/abstract/id.rb:226:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/cookies.rb:613:in `call'
activerecord (5.1.2) lib/active_record/migration.rb:556:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/callbacks.rb:26:in `block in call'
activesupport (5.1.2) lib/active_support/callbacks.rb:97:in `run_callbacks'
actionpack (5.1.2) lib/action_dispatch/middleware/callbacks.rb:24:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/debug_exceptions.rb:59:in `call'
web-console (3.5.1) lib/web_console/middleware.rb:135:in `call_app'
web-console (3.5.1) lib/web_console/middleware.rb:28:in `block in call'
web-console (3.5.1) lib/web_console/middleware.rb:18:in `catch'
web-console (3.5.1) lib/web_console/middleware.rb:18:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
railties (5.1.2) lib/rails/rack/logger.rb:36:in `call_app'
railties (5.1.2) lib/rails/rack/logger.rb:24:in `block in call'
activesupport (5.1.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
activesupport (5.1.2) lib/active_support/tagged_logging.rb:26:in `tagged'
activesupport (5.1.2) lib/active_support/tagged_logging.rb:69:in `tagged'
railties (5.1.2) lib/rails/rack/logger.rb:24:in `call'
sprockets-rails (3.2.0) lib/sprockets/rails/quiet_assets.rb:13:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/request_id.rb:25:in `call'
rack (2.0.3) lib/rack/method_override.rb:22:in `call'
rack (2.0.3) lib/rack/runtime.rb:22:in `call'
activesupport (5.1.2) lib/active_support/cache/strategy/local_cache_middleware.rb:27:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.1.2) lib/action_dispatch/middleware/static.rb:125:in `call'
rack (2.0.3) lib/rack/sendfile.rb:111:in `call'
railties (5.1.2) lib/rails/engine.rb:522:in `call'
puma (3.9.1) lib/puma/configuration.rb:224:in `call'
puma (3.9.1) lib/puma/server.rb:602:in `handle_request'
puma (3.9.1) lib/puma/server.rb:435:in `process_client'
puma (3.9.1) lib/puma/server.rb:299:in `block in run'
puma (3.9.1) lib/puma/thread_pool.rb:120:in `block in spawn_thread'
Started GET "/" for 127.0.0.1 at 2017-07-17 12:05:10 -0700