### PR TITLE
Migration changes needed for rails 5.1 (and spree 3.3)

### DIFF
--- a/db/migrate/20150904143013_create_spree_braintree_checkouts.rb
+++ b/db/migrate/20150904143013_create_spree_braintree_checkouts.rb
@@ -1,4 +1,4 @@
-class CreateSpreeBraintreeCheckouts < ActiveRecord::Migration
+class CreateSpreeBraintreeCheckouts < ActiveRecord::Migration[5.0]
   def change
     create_table :spree_braintree_checkouts do |t|
       t.string :transaction_id, index: true

--- a/db/migrate/20151002094655_add_braintree_id_to_spree_addresses.rb
+++ b/db/migrate/20151002094655_add_braintree_id_to_spree_addresses.rb
@@ -1,4 +1,4 @@
-class AddBraintreeIdToSpreeAddresses < ActiveRecord::Migration
+class AddBraintreeIdToSpreeAddresses < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_addresses, :braintree_id, :string
   end

--- a/db/migrate/20151018123907_add_braintree_token_and_nonce_to_spree_payments.rb
+++ b/db/migrate/20151018123907_add_braintree_token_and_nonce_to_spree_payments.rb
@@ -1,4 +1,4 @@
-class AddBraintreeTokenAndNonceToSpreePayments < ActiveRecord::Migration
+class AddBraintreeTokenAndNonceToSpreePayments < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_payments, :braintree_token, :string
     add_column :spree_payments, :braintree_nonce, :string

--- a/db/migrate/20151027135109_add_paypal_email_to_spree_braintree_checkout.rb
+++ b/db/migrate/20151027135109_add_paypal_email_to_spree_braintree_checkout.rb
@@ -1,4 +1,4 @@
-class AddPaypalEmailToSpreeBraintreeCheckout < ActiveRecord::Migration
+class AddPaypalEmailToSpreeBraintreeCheckout < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_braintree_checkouts, :paypal_email, :string
   end

--- a/db/migrate/20151028095515_add_advanced_fraud_data_to_spree_braintree_checkout.rb
+++ b/db/migrate/20151028095515_add_advanced_fraud_data_to_spree_braintree_checkout.rb
@@ -1,4 +1,4 @@
-class AddAdvancedFraudDataToSpreeBraintreeCheckout < ActiveRecord::Migration
+class AddAdvancedFraudDataToSpreeBraintreeCheckout < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_braintree_checkouts, :advanced_fraud_data, :string
   end

--- a/db/migrate/20151202095956_add_risk_id_and_risk_decision_to_spree_braintree_checkouts.rb
+++ b/db/migrate/20151202095956_add_risk_id_and_risk_decision_to_spree_braintree_checkouts.rb
@@ -1,4 +1,4 @@
-class AddRiskIdAndRiskDecisionToSpreeBraintreeCheckouts < ActiveRecord::Migration
+class AddRiskIdAndRiskDecisionToSpreeBraintreeCheckouts < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_braintree_checkouts, :risk_id, :string
     add_column :spree_braintree_checkouts, :risk_decision, :string

--- a/db/migrate/20151211100203_add_braintree_last_digits_and_braintree_card_type_to_spree_braintree_checkouts.rb
+++ b/db/migrate/20151211100203_add_braintree_last_digits_and_braintree_card_type_to_spree_braintree_checkouts.rb
@@ -1,4 +1,4 @@
-class AddBraintreeLastDigitsAndBraintreeCardTypeToSpreeBraintreeCheckouts < ActiveRecord::Migration
+class AddBraintreeLastDigitsAndBraintreeCardTypeToSpreeBraintreeCheckouts < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_braintree_checkouts, :braintree_last_digits, :string, limit: 4
     add_column :spree_braintree_checkouts, :braintree_card_type, :string

--- a/db/migrate/20160112153422_add_admin_payment_to_spree_braintree_checkout.rb
+++ b/db/migrate/20160112153422_add_admin_payment_to_spree_braintree_checkout.rb
@@ -1,4 +1,4 @@
-class AddAdminPaymentToSpreeBraintreeCheckout < ActiveRecord::Migration
+class AddAdminPaymentToSpreeBraintreeCheckout < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_braintree_checkouts, :admin_payment, :bool
   end


### PR DESCRIPTION
Rails 5.1 and therefore spree 3.3 need migrations to include the rails version for which they were made.