### PR TITLE
Fix for SystemStackError (stack level too deep) issue in production (#80)

### DIFF
--- a/app/helpers/spree/admin/decorated_navigation_helper.rb
+++ b/app/helpers/spree/admin/decorated_navigation_helper.rb
@@ -1,0 +1,10 @@
+module Spree
+  module Admin
+    module DecoratedNavigationHelper
+      def link_to_with_icon(icon_name, text, url, options = {})
+        icon_name = 'capture' if icon_name.eql?('settle')
+        super
+      end
+    end
+  end
+end

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -1,8 +1,0 @@
-Spree::Admin::NavigationHelper.module_eval do
-  alias_method :original_link_to_with_icon, :link_to_with_icon
-
-  def link_to_with_icon(icon_name, text, url, options = {})
-    icon_name = 'capture' if icon_name.eql?('settle')
-    original_link_to_with_icon(icon_name, text, url, options)
-  end
-end

--- a/config/initializers/prepend_helpers.rb
+++ b/config/initializers/prepend_helpers.rb
@@ -1,0 +1,1 @@
+Spree::Admin::NavigationHelper.prepend(Spree::Admin::DecoratedNavigationHelper)


### PR DESCRIPTION
Hello,

I’ve experienced the #80 issue when I deployed an application with this gem to production. I couldn’t figure out why is the `Spree::Admin::NavigationHelper` being loaded twice, but I’ve found a solution to the problem with `Module#prepend`.