### PR TITLE
Fix for PayPal and dropin payment methods ignoring store_credit

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -140,7 +140,7 @@ Spree::Order.class_eval do
       order.errors.add(:base, Spree.t(:no_payment_found))
       false
     else
-      payments.valid.last.update(amount: total)
+      payments.valid.last.update(amount: order_total_after_store_credit)
       process_payments!
     end
   end

--- a/app/views/spree/shared/braintree_vzero/_dropin.js.erb
+++ b/app/views/spree/shared/braintree_vzero/_dropin.js.erb
@@ -1,7 +1,7 @@
 container: container,
 paypal: {
   singleUse: <%= payment_method.preferred_store_payments_in_vault.eql?('do_not_store') %>,
-  amount: <%= @order.total %>,
+  amount: <%= @order.order_total_after_store_credit %>,
   currency: "<%= current_currency %>",
   enableShippingAddress: true,
   shippingAddressOverride: {
@@ -43,7 +43,7 @@ onPaymentMethodReceived: function (result) {
     });
 
     client.verify3DS({
-      amount: <%= @order.total %>,
+      amount: <%= @order.order_total_after_store_credit %>,
       creditCard: result.nonce
     }, function (error, response) {
       if (!error) {

--- a/app/views/spree/shared/braintree_vzero/_hosted.js.erb
+++ b/app/views/spree/shared/braintree_vzero/_hosted.js.erb
@@ -50,7 +50,7 @@ onPaymentMethodReceived: function (result) {
     });
 
     client.verify3DS({
-      amount: <%= @order.total %>,
+      amount: <%= @order.order_total_after_store_credit %>,
       creditCard: result.nonce
     }, function (error, response) {
       if (!error) {

--- a/app/views/spree/shared/braintree_vzero/_paypal.js.erb
+++ b/app/views/spree/shared/braintree_vzero/_paypal.js.erb
@@ -1,6 +1,6 @@
 container: "paypal-container",
 singleUse: <%= payment_method.preferred_store_payments_in_vault.eql?('do_not_store') %>,
-amount: <%= @order.total %>,
+amount: <%= @order.order_total_after_store_credit %>,
 currency: "<%= current_currency %>",
 locale: "en_us",
 displayName: "<%= payment_method.preferred_paypal_display_name %>",

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -78,7 +78,7 @@ describe Spree::CheckoutController, :vcr, type: :controller do
       it 'amount in payment should be updated' do
         expect(order.reload.payments.sum(:amount)).to eq 0
         put :update, params: { state: 'confirm' }
-        expect(order.reload.payments.last.amount).to eq order.total
+        expect(order.reload.payments.last.amount).to eq order.order_total_after_store_credit
       end
     end
   end


### PR DESCRIPTION
Changed `order.total` to `order.order_total_after_store_credit` so store credit isn't ignored.