### PR TITLE
Coupon application fix when paying with PayPal

### DIFF
--- a/app/views/spree/checkout/payment/braintree_vzero/_payment.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_payment.html.erb
@@ -96,7 +96,7 @@
             };
             if ($.trim(input.couponCodeField.val()).length > 0) {
               if (new CouponManager(input).applyCoupon()) {
-                submit();
+                location.reload();
                 return true;
               } else {
                 Spree.enableSave();

--- a/app/views/spree/checkout/payment/braintree_vzero/_payment.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_payment.html.erb
@@ -90,7 +90,22 @@
         document.querySelector(paypalSubmitId).addEventListener(
           "click",
           function () {
-            checkout.paypal.initAuthFlow();
+            input = {
+              couponCodeField: $('#order_coupon_code'),
+              couponStatus: $('#coupon_status')
+            };
+            if ($.trim(input.couponCodeField.val()).length > 0) {
+              if (new CouponManager(input).applyCoupon()) {
+                submit();
+                return true;
+              } else {
+                Spree.enableSave();
+                event.preventDefault();
+                return false;
+              }
+            } else {
+              checkout.paypal.initAuthFlow();
+            }
           },
           false
         );


### PR DESCRIPTION
Should fix issue #181
Spree already has javascript to do this but, since the button used to continue when paying with PayPal is not an actual submit button, said javascript was not being triggered.
