### PR TITLE
Fix for admin/payments_controller_decorator being outdated and causing some bugs

### DIFF
--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -1,55 +1,15 @@
 Spree::Admin::PaymentsController.class_eval do
-  before_action :initBraintree, only: [:create]
-  # def create
-  #   invoke_callbacks(:create, :before)
+  create.before :initBraintree
 
-  #   begin
-  #     if @payment_method.store_credit?
-  #       payments = @order.add_store_credit_payments
-  #     else
-  #       @payment ||= @order.payments.build(object_params)
-  #       if @payment.payment_method.source_required? 
-  #         if params[:card].present? && params[:card] != 'new'
-  #           @payment.source = @payment.payment_method.payment_source_class.find_by(id: params[:card])
-  #         elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-  #           @payment.braintree_token = params[:payment_method_token]
-  #           @payment.braintree_nonce = params[:payment_method_nonce]
-  #           @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
-  #         end
-  #       end
-  #       @payment.save
-  #       payments = [@payment]
-  #     end
-
-  #     if payments && (saved_payments = payments.select &:persisted?).any?
-  #       invoke_callbacks(:create, :after)
-
-  #       # Transition order as far as it will go.
-  #       while @order.next; end
-  #       # If "@order.next" didn't trigger payment processing already (e.g. if the order was
-  #       # already complete) then trigger it manually now
-
-  #       saved_payments.each { |payment| payment.process! if payment.reload.checkout? && @order.complete? }
-  #       flash[:success] = flash_message_for(saved_payments.first, :successfully_created)
-  #       redirect_to admin_order_payments_path(@order)
-  #     else
-  #       @payment ||= @order.payments.build(object_params)
-  #       invoke_callbacks(:create, :fails)
-  #       flash[:error] = Spree.t(:payment_could_not_be_created)
-  #       render :new
-  #     end
-  #   rescue Spree::Core::GatewayError => e
-  #     invoke_callbacks(:create, :fails)
-  #     flash[:error] = e.message.to_s
-  #     redirect_to new_admin_order_payment_path(@order)
-  #   end
-  # end
   private
   def initBraintree
-    if @payment.payment_method.source_required? && @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-      @payment.braintree_token = params[:payment_method_token]
-      @payment.braintree_nonce = params[:payment_method_nonce]
-      @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
+    unless @payment_method.store_credit?
+      @payment ||= @order.payments.build(object_params)
+      if @payment.payment_method.source_required? && @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+        @payment.braintree_token = params[:payment_method_token]
+        @payment.braintree_nonce = params[:payment_method_nonce]
+        @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
+      end
     end
   end
 end

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -4,13 +4,17 @@ Spree::Admin::PaymentsController.class_eval do
   private
   
   def init_braintree
-    unless @payment_method.store_credit?
-      @payment ||= @order.payments.build(object_params)
-      if @payment.payment_method.source_required? && @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-        @payment.braintree_token = params[:payment_method_token]
-        @payment.braintree_nonce = params[:payment_method_nonce]
-        @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
-      end
+    return if @payment_method.store_credit?
+    @payment ||= @order.payments.build(object_params)
+    if braintree_source?(@payment)
+      @payment.braintree_token = params[:payment_method_token]
+      @payment.braintree_nonce = params[:payment_method_nonce]
+      @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
     end
+  end
+
+  def braintree_source?(payment)
+    return payment.payment_method.source_required? && 
+          payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
   end
 end

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -2,7 +2,7 @@ Spree::Admin::PaymentsController.class_eval do
   create.before :init_braintree
 
   private
-  
+
   def init_braintree
     return if @payment_method.store_credit?
     @payment ||= @order.payments.build(object_params)
@@ -14,7 +14,7 @@ Spree::Admin::PaymentsController.class_eval do
   end
 
   def braintree_source?(payment)
-    return payment.payment_method.source_required? && 
-          payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+    payment.payment_method.source_required? &&
+    payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
   end
 end

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -6,15 +6,15 @@ Spree::Admin::PaymentsController.class_eval do
   def init_braintree
     return if @payment_method.store_credit?
     @payment ||= @order.payments.build(object_params)
-    if braintree_source?(@payment)
-      @payment.braintree_token = params[:payment_method_token]
-      @payment.braintree_nonce = params[:payment_method_nonce]
-      @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
-    end
+
+    return unless braintree_source?(@payment)
+    @payment.braintree_token = params[:payment_method_token]
+    @payment.braintree_nonce = params[:payment_method_nonce]
+    @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
   end
 
   def braintree_source?(payment)
     payment.payment_method.source_required? &&
-    payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+      payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
   end
 end

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -1,37 +1,55 @@
 Spree::Admin::PaymentsController.class_eval do
-  def create
-    invoke_callbacks(:create, :before)
-    @payment ||= @order.payments.build(object_params)
-    # not only credit card may require source
-    if @payment.payment_method.source_required?
-      if params[:card].present? && params[:card] != 'new'
-        @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
-      elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-        @payment.braintree_token = params[:payment_method_token]
-        @payment.braintree_nonce = params[:payment_method_nonce]
-        @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
-      end
-    end
+  before_action :initBraintree, only: [:create]
+  # def create
+  #   invoke_callbacks(:create, :before)
 
-    begin
-      if @payment.save
-        invoke_callbacks(:create, :after)
-        # Transition order as far as it will go.
-        while @order.next; end
-        # If "@order.next" didn't trigger payment processing already (e.g. if the order was
-        # already complete) then trigger it manually now
-        @payment.process! if @order.completed? && @payment.checkout?
-        flash[:success] = flash_message_for(@payment, :successfully_created)
-        redirect_to admin_order_payments_path(@order)
-      else
-        invoke_callbacks(:create, :fails)
-        flash[:error] = Spree.t(:payment_could_not_be_created)
-        render :new
-      end
-    rescue Spree::Core::GatewayError => e
-      invoke_callbacks(:create, :fails)
-      flash[:error] = e.message.to_s
-      redirect_to new_admin_order_payment_path(@order)
+  #   begin
+  #     if @payment_method.store_credit?
+  #       payments = @order.add_store_credit_payments
+  #     else
+  #       @payment ||= @order.payments.build(object_params)
+  #       if @payment.payment_method.source_required? 
+  #         if params[:card].present? && params[:card] != 'new'
+  #           @payment.source = @payment.payment_method.payment_source_class.find_by(id: params[:card])
+  #         elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+  #           @payment.braintree_token = params[:payment_method_token]
+  #           @payment.braintree_nonce = params[:payment_method_nonce]
+  #           @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
+  #         end
+  #       end
+  #       @payment.save
+  #       payments = [@payment]
+  #     end
+
+  #     if payments && (saved_payments = payments.select &:persisted?).any?
+  #       invoke_callbacks(:create, :after)
+
+  #       # Transition order as far as it will go.
+  #       while @order.next; end
+  #       # If "@order.next" didn't trigger payment processing already (e.g. if the order was
+  #       # already complete) then trigger it manually now
+
+  #       saved_payments.each { |payment| payment.process! if payment.reload.checkout? && @order.complete? }
+  #       flash[:success] = flash_message_for(saved_payments.first, :successfully_created)
+  #       redirect_to admin_order_payments_path(@order)
+  #     else
+  #       @payment ||= @order.payments.build(object_params)
+  #       invoke_callbacks(:create, :fails)
+  #       flash[:error] = Spree.t(:payment_could_not_be_created)
+  #       render :new
+  #     end
+  #   rescue Spree::Core::GatewayError => e
+  #     invoke_callbacks(:create, :fails)
+  #     flash[:error] = e.message.to_s
+  #     redirect_to new_admin_order_payment_path(@order)
+  #   end
+  # end
+  private
+  def initBraintree
+    if @payment.payment_method.source_required? && @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+      @payment.braintree_token = params[:payment_method_token]
+      @payment.braintree_nonce = params[:payment_method_nonce]
+      @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
     end
   end
 end

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -1,8 +1,9 @@
 Spree::Admin::PaymentsController.class_eval do
-  create.before :initBraintree
+  create.before :init_braintree
 
   private
-  def initBraintree
+  
+  def init_braintree
     unless @payment_method.store_credit?
       @payment ||= @order.payments.build(object_params)
       if @payment.payment_method.source_required? && @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)


### PR DESCRIPTION
The code in this decorator was severely outdated. I refactored it a bit so it uses a callback, should be easier to maintain it this way.
There were some bugs caused by this, mainly there was no support for store credit and the first payment always failed due to it being performed two times