### PR TITLE
Ensures a common interface for utils

### DIFF
--- a/app/models/spree/gateway/braintree_vzero_base.rb
+++ b/app/models/spree/gateway/braintree_vzero_base.rb
@@ -152,13 +152,13 @@ module Spree
       Braintree::ErrorResult.new(:transaction, params: data, errors: { transaction: errors }, message: message)
     end
 
-    def braintree_user(provider, user, order)
-      Gateway::BraintreeVzeroBase::BraintreeUser.new(provider, user, order).user
+    def braintree_user(user, order)
+      Gateway::BraintreeVzeroBase::BraintreeUser.new(self, user, order).user
     end
 
     def token_params(provider, user, order)
       token_params = {}
-      token_params[:customer_id] = user.id if braintree_user(provider, user, order)
+      token_params[:customer_id] = user.id if braintree_user(user, order)
       currency = order.try(:currency)
       merchant_account_id = currency ? get_merchant_account(currency) : nil
       token_params[:merchant_account_id] = merchant_account_id if merchant_account_id

--- a/app/models/spree/gateway/braintree_vzero_base/address.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/address.rb
@@ -2,16 +2,21 @@ module Spree
   class Gateway
     class BraintreeVzeroBase
       class Address
-        attr_reader :user, :utils, :request
+        attr_reader :user, :request
 
-        def initialize(provider, order)
-          @utils = Utils.new(provider, order)
+        def initialize(gateway, order)
+          @gateway = gateway
+          @order = order
           @user = order.user
-          @request = provider::Address
+          @request = gateway.provider::Address
+        end
+
+        def utils
+          @_utils ||= Utils.new(@gateway, @order)
         end
 
         def create
-          @request.create(@utils.address_data('billing', utils.order).merge!(customer_id: user.id.to_s))
+          @request.create(utils.address_data('billing', utils.order).merge!(customer_id: user.id.to_s))
         end
 
         def find(braintree_address)

--- a/app/models/spree/gateway/braintree_vzero_base/braintree_user.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/braintree_user.rb
@@ -2,22 +2,27 @@ module Spree
   class Gateway
     class BraintreeVzeroBase
       class BraintreeUser
-        attr_reader :user, :spree_user, :request, :utils
+        attr_reader :user, :spree_user, :request
 
         delegate :shipping_address, :billing_address, to: :spree_user
 
-        def initialize(provider, spree_user, order)
-          @utils = Utils.new(provider, order)
+        def initialize(gateway, spree_user, order)
           @spree_user = spree_user
-          @request = provider::Customer
+          @order = order
+          @gateway = gateway
+          @request = gateway.provider::Customer
           begin
             @user = @request.find(spree_user.try(:id))
           rescue
           end
         end
 
+        def utils
+          @_utils ||= Utils.new(@gateway, @order)
+        end
+
         def register_user
-          @request.create(@utils.customer_data(spree_user))
+          @request.create(utils.customer_data(spree_user))
         end
       end
     end

--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -8,14 +8,14 @@ module Spree
           @order = order
           begin
             @customer = gateway.provider::Customer.find(order.user.id) if order.user
-          rescue
+          rescue Braintree::NotFoundError
           end
           @gateway = gateway
         end
 
         def get_address(address_type)
           if order.user && (address = order.user.send("#{address_type}_address"))
-            braintree_address = BraintreeVzeroBase::Address.new(gateway.provider, order)
+            braintree_address = BraintreeVzeroBase::Address.new(gateway, order)
             vaulted_duplicate = Spree::Address.vaulted_duplicates(address).first
 
             if vaulted_duplicate && braintree_address.find(vaulted_duplicate.braintree_id)

--- a/spec/models/gateway/braintree_vzero_base/address_spec.rb
+++ b/spec/models/gateway/braintree_vzero_base/address_spec.rb
@@ -4,7 +4,7 @@ describe Spree::Gateway::BraintreeVzeroBase::Address, :vcr do
   let(:gateway) { create(:vzero_gateway, auto_capture: true) }
   let(:user) { create(:user) }
   let(:order) { create(:order) }
-  let(:braintree_address) { Spree::Gateway::BraintreeVzeroBase::Address.new(gateway.provider, order) }
+  let(:braintree_address) { Spree::Gateway::BraintreeVzeroBase::Address.new(gateway, order) }
 
   context '#create' do
     it 'creates Braintree Address' do

--- a/spec/models/gateway/braintree_vzero_base_spec.rb
+++ b/spec/models/gateway/braintree_vzero_base_spec.rb
@@ -22,7 +22,7 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
 
     it 'generates token for User registered in Braintree' do
       user = create(:user, billing_address: create(:address))
-      Spree::Gateway::BraintreeVzeroBase::BraintreeUser.new(gateway.provider, user, order).register_user
+      Spree::Gateway::BraintreeVzeroBase::BraintreeUser.new(gateway, user, order).register_user
       expect(gateway.client_token(order, user)).to_not be_nil
     end
 


### PR DESCRIPTION
Previously two disperate objects could be passed into utils, a `Gateway`
or a `Provider`.  This changes the signature to always expect a `Gateway`
It reduces the potential impact of this change from causing a double
lookup by lazy loading utils.

There are most likely additional refactors that are required here but
this allows the utils class not swallow unrelated errors.