### PR TITLE
Fixed null avs_response in spree_payments table

### DIFF
--- a/app/models/braintree/successful_response_decorator.rb
+++ b/app/models/braintree/successful_response_decorator.rb
@@ -6,7 +6,7 @@ Braintree::SuccessfulResult.class_eval do
   end
 
   def avs_result
-    { code: transaction.avs_street_address_response_code }
+    { code: transaction.avs_street_address_response_code }.with_indifferent_access
   end
 
   def cvv_result


### PR DESCRIPTION
Fixed bug that prevented avs_response from being saved into the database.