### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_braintree_vzero.gemspec
+++ b/spree_braintree_vzero.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_extension'
 
   s.add_dependency 'braintree', '>= 2.40.0'
+  s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'whenever'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here