### PR TITLE
[SD-1007] Spree 4.0 support

### DIFF
--- a/app/assets/images/backend-settle.svg
+++ b/app/assets/images/backend-settle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2">
+  <path fill="currentColor" d="M474.975 82.072c-5.79-5.77-15.123-5.77-20.874 0L173.92 362.589 58.76 247.27c-5.75-5.75-15.085-5.79-20.874 0-5.77 5.75-5.77 15.104 0 20.874l125.597 125.774c2.875 2.895 6.656 4.333 10.437 4.333 3.8 0 7.562-1.438 10.437-4.333l290.62-290.953c5.769-5.77 5.769-15.144 0-20.894z" fill-rule="nonzero" stroke="currentColor" stroke-width="24.024606"/>
+</svg>

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -8,11 +8,11 @@ module Spree
         if @payment.payment_method.source_required?
           if params[:card].present? && params[:card] != 'new'
             @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
-          elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-            @payment.braintree_token = params[:payment_method_token]
-            @payment.braintree_nonce = params[:payment_method_nonce]
-            @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
           end
+        elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+          @payment.braintree_token = params[:payment_method_token]
+          @payment.braintree_nonce = params[:payment_method_nonce]
+          @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
         end
 
         begin

--- a/app/models/spree/gateway/braintree_vzero_base.rb
+++ b/app/models/spree/gateway/braintree_vzero_base.rb
@@ -87,6 +87,10 @@ module Spree
       provider::PaymentMethod.find(token)
     end
 
+    def source_required?
+      false
+    end
+
     private
 
     def sale(data, order, source = nil)

--- a/app/models/spree/payment_processing_decorator.rb
+++ b/app/models/spree/payment_processing_decorator.rb
@@ -57,6 +57,7 @@ module Spree
     end
 
     def handle_payment_preconditions
+      return unless payment_method
       unless block_given?
         raise ArgumentError, 'handle_payment_preconditions must be called with a block'
       end

--- a/app/models/spree/payment_processing_decorator.rb
+++ b/app/models/spree/payment_processing_decorator.rb
@@ -57,27 +57,15 @@ module Spree
     end
 
     def handle_payment_preconditions
-      return unless payment_method
       unless block_given?
         raise ArgumentError, 'handle_payment_preconditions must be called with a block'
       end
 
-      if payment_method&.source_required?
-        if source
-          unless processing?
-            if payment_method.supports?(source) || token_based?
-              yield
-            else
-              invalidate!
-              raise Core::GatewayError, Spree.t(:payment_method_not_supported)
-            end
-          end
-        else
-          raise Core::GatewayError, Spree.t(:payment_processing_failed)
-        end
-      else
-        yield
-      end
+      braintree_payment_method? ? yield : super
+    end
+
+    def braintree_payment_method?
+      payment_method.provider == Braintree
     end
   end
 end

--- a/app/models/spree/payment_processing_decorator.rb
+++ b/app/models/spree/payment_processing_decorator.rb
@@ -55,6 +55,29 @@ module Spree
         current_state
       end
     end
+
+    def handle_payment_preconditions
+      unless block_given?
+        raise ArgumentError, 'handle_payment_preconditions must be called with a block'
+      end
+
+      if payment_method&.source_required?
+        if source
+          unless processing?
+            if payment_method.supports?(source) || token_based?
+              yield
+            else
+              invalidate!
+              raise Core::GatewayError, Spree.t(:payment_method_not_supported)
+            end
+          end
+        else
+          raise Core::GatewayError, Spree.t(:payment_processing_failed)
+        end
+      else
+        yield
+      end
+    end
   end
 end
 

--- a/app/overrides/spree/orders/edit.rb
+++ b/app/overrides/spree/orders/edit.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
   virtual_path: 'spree/orders/edit',
   name: 'Add PayPal button',
-  insert_before: 'erb[loud]:contains("checkout-link")',
+  insert_after: 'erb[loud]:contains("checkout-link")',
   partial: 'spree/braintree_vzero/paypal_checkout'
 )

--- a/app/views/spree/braintree_vzero/_paypal_checkout.html.erb
+++ b/app/views/spree/braintree_vzero/_paypal_checkout.html.erb
@@ -8,80 +8,80 @@
   <script src="https://js.braintreegateway.com/js/braintree-2.32.1.min.js"></script>
 
   <script type="text/javascript">
-    var checkoutFormId = '#update-cart';
-    var checkout;
-    SpreeBraintreeVzero.checkoutFormId = '#update-cart';
+    // TODO: Investiagate what kind of checkout (if any) steps should be included during paypal express payment
+    window.addEventListener('DOMContentLoaded', function() {
+      var checkoutFormId = '#update-cart';
+      var checkout;
+      SpreeBraintreeVzero.checkoutFormId = '#update-cart';
 
-    braintree.setup("<%= payment_method.client_token(current_order) %>", "paypal", {
-      container: "paypal-container",
-      singleUse: <%= payment_method.preferred_store_payments_in_vault.eql?('do_not_store') %>,
-      amount: <%= @order.total %>,
-      currency: "<%= current_currency %>",
-      locale: "en_us",
-      enableShippingAddress: true,
-      enableBillingAddress: true,
-      displayName: "<%= payment_method.preferred_paypal_display_name %>",
-      <% if payment_method.preferred_advanced_fraud_tools %>
+      braintree.setup("<%= payment_method.client_token(current_order) %>", "paypal", {
+        container: "paypal-container",
+        singleUse: <%= payment_method.preferred_store_payments_in_vault.eql?('do_not_store') %>,
+        amount: <%= @order.total %>,
+        currency: "<%= current_currency %>",
+        locale: "en_us",
+        enableShippingAddress: true,
+        enableBillingAddress: true,
+        displayName: "<%= payment_method.preferred_paypal_display_name %>",
+        <% if payment_method.preferred_advanced_fraud_tools %>
         dataCollector: {
           kount: {
             environment: "<%= payment_method.preferred_server %>"
             <% if (kount_id = payment_method.preferred_kount_merchant_id).present? %>
-              ,
-              merchantId: "<%= kount_id %>"
+            ,
+            merchantId: "<%= kount_id %>"
             <% end %>
           }
         },
-      <% end %>
+        <% end %>
 
-      onReady: function (integration) {
-        SpreeBraintreeVzero.deviceData = integration.deviceData;
-        checkout = integration;
-      },
-      headless: true,
+        onReady: function (integration) {
+          SpreeBraintreeVzero.deviceData = integration.deviceData;
+          checkout = integration;
+        },
+        headless: true,
 
-      onPaymentMethodReceived: function (result) {
-        $('#paypal-container').hide()
-        $('#checkout-link').prop("disabled", true);
-        phone = result.details.phone
-        SpreeBraintreeVzero.addDeviceData();
+        onPaymentMethodReceived: function (result) {
+          $('#paypal-container').hide()
+          $('#checkout-link').prop("disabled", true);
+          phone = result.details.phone
+          SpreeBraintreeVzero.addDeviceData();
 
-        if(shippingAddress = result.details.shippingAddress) {
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][zipcode]' value='" + shippingAddress.postalCode + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][full_name]' value='" + shippingAddress.recipientName + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][firstname]' value='" + result.details.firstName + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][lastname]' value='" + result.details.lastName + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][address1]' value='" + shippingAddress.streetAddress + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][address2]' value='" + shippingAddress.extendedAddress + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][city]' value='" + shippingAddress.locality + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][country]' value='" + shippingAddress.countryCodeAlpha2 + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[ship_address][state]' value='" + shippingAddress.region + "'>");
-          if(phone)
-            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][phone]' value='" + phone + "'>");
+          if (shippingAddress = result.details.shippingAddress) {
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][zipcode]' value='" + shippingAddress.postalCode + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][full_name]' value='" + shippingAddress.recipientName + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][firstname]' value='" + result.details.firstName + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][lastname]' value='" + result.details.lastName + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][address1]' value='" + shippingAddress.streetAddress + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][address2]' value='" + shippingAddress.extendedAddress + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][city]' value='" + shippingAddress.locality + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][country]' value='" + shippingAddress.countryCodeAlpha2 + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[ship_address][state]' value='" + shippingAddress.region + "'>");
+            if (phone)
+              $(checkoutFormId).append("<input type='hidden' name='order[ship_address][phone]' value='" + phone + "'>");
+          }
+
+          if (billingAddress = result.details.billingAddress) {
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][zipcode]' value='" + billingAddress.postalCode + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][firstname]' value='" + result.details.firstName + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][lastname]' value='" + result.details.lastName + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][address1]' value='" + billingAddress.streetAddress + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][address2]' value='" + billingAddress.extendedAddress + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][city]' value='" + billingAddress.locality + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][country]' value='" + billingAddress.countryCodeAlpha2 + "'>");
+            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][state]' value='" + billingAddress.region + "'>");
+            if (phone)
+              $(checkoutFormId).append("<input type='hidden' name='order[bill_address][phone]' value='" + phone + "'>");
+          }
+
+          $(checkoutFormId).append("<input type='hidden' name='order[email]' value=" + result.details.email + ">");
+          $(checkoutFormId).append("<input type='hidden' name='paypal[payment_method_nonce]' value=" + result.nonce + ">");
+          $(checkoutFormId).append("<input type='hidden' name='checkout' value=true>");
+
+          $(checkoutFormId).submit();
         }
-
-        if(billingAddress = result.details.billingAddress) {
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][zipcode]' value='" + billingAddress.postalCode + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][firstname]' value='" + result.details.firstName + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][lastname]' value='" + result.details.lastName + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][address1]' value='" + billingAddress.streetAddress + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][address2]' value='" + billingAddress.extendedAddress + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][city]' value='" + billingAddress.locality + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][country]' value='" + billingAddress.countryCodeAlpha2 + "'>");
-          $(checkoutFormId).append("<input type='hidden' name='order[bill_address][state]' value='" + billingAddress.region + "'>");
-          if(phone)
-            $(checkoutFormId).append("<input type='hidden' name='order[bill_address][phone]' value='" + phone + "'>");
-        }
-
-        $(checkoutFormId).append("<input type='hidden' name='order[email]' value=" + result.details.email + ">");
-        $(checkoutFormId).append("<input type='hidden' name='paypal[payment_method_nonce]' value=" + result.nonce + ">");
-        $(checkoutFormId).append("<input type='hidden' name='checkout' value=true>");
-
-        $(checkoutFormId).submit();
-      }
+      });
+      document.querySelector('#btnOpenFlow').addEventListener('click', function () { checkout.paypal.initAuthFlow(); }, false);
     });
-
-    document.querySelector('#btnOpenFlow').addEventListener('click', function () { checkout.paypal.initAuthFlow(); }, false);
   </script>
-<% else %>
-  &nbsp;
 <% end %>

--- a/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
@@ -1,218 +1,220 @@
 <script type="text/javascript">
-  $('#order_payments_attributes__payment_method_id_<%= payment_method.id %>').click(function (e) {
-    var threeDSecure;
-    var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
-    var formId = "#" + checkoutFormId;
+    window.addEventListener('load', function() {
+        $('#order_payments_attributes__payment_method_id_<%= payment_method.id %>').click(function (e) {
+            var threeDSecure;
+            var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
+            var formId = "#" + checkoutFormId;
 
-    var clientToken = "<%= payment_method.client_token(@order) %>";
+            var clientToken = "<%= payment_method.client_token(@order) %>";
 
-    <% if hosted %>
-    var hf, threeDS;
-    var hostedFieldsContainer = document.getElementById('hosted-fields');
-    <% elsif dropin%>
-    var dropin;
-    <% end %>
+            <% if hosted %>
+            var hf, threeDS;
+            var hostedFieldsContainer = document.getElementById('hosted-fields');
+            <% elsif dropin%>
+            var dropin;
+            <% end %>
 
-    var payBtn = document.getElementsByName('commit')[0];
-    var payGroup = $('.pay-group');
-    var billingFields = [
-      'email',
-    ].reduce(function (fields, fieldName) {
-      var field = fields[fieldName] = {
-        input: document.getElementById(fieldName),
-        help: document.getElementById('help-' + fieldName)
-      };
+            var payBtn = document.getElementsByName('commit')[0];
+            var payGroup = $('.pay-group');
+            var billingFields = [
+                'email',
+            ].reduce(function (fields, fieldName) {
+                var field = fields[fieldName] = {
+                    input: document.getElementById(fieldName),
+                    help: document.getElementById('help-' + fieldName)
+                };
 
-      field.input.addEventListener('focus', function() {
-        clearFieldValidations(field);
-      });
+                field.input.addEventListener('focus', function() {
+                    clearFieldValidations(field);
+                });
 
-      return fields;
-    }, {});
+                return fields;
+            }, {});
 
-    function clearFieldValidations (field) {
-      field.help.innerText = '';
-      field.help.parentNode.classList.remove('has-error');
-    }
-
-    function validateBillingFields() {
-      var isValid = true;
-
-      Object.keys(billingFields).forEach(function (fieldName) {
-        var fieldEmpty = false;
-        var field = billingFields[fieldName];
-
-        if (field.optional) {
-          return;
-        }
-
-        fieldEmpty = field.input.value.trim() === '';
-
-        if (fieldEmpty) {
-          isValid = false;
-          field.help.innerText = "<%= Spree.t(:required) %>";
-          field.help.parentNode.classList.add('has-error');
-        } else {
-          clearFieldValidations(field);
-        }
-      });
-
-      return isValid;
-    }
-
-    function start() {
-      getClientToken();
-    }
-
-    function getClientToken() {
-      onFetchClientToken(clientToken);
-    }
-
-    function setupComponents (clientToken) {
-      return Promise.all([
-        braintree.hostedFields.create({
-          authorization: clientToken,
-          styles: {
-            input: {
-              'font-size': '14px',
-              'font-family': 'monospace'
+            function clearFieldValidations (field) {
+                field.help.innerText = '';
+                field.help.parentNode.classList.remove('has-error');
             }
-          },
-          fields: {
-            number: {
-              selector: '#hosted-fields-number'
-            },
-            cvv: {
-              selector: '#hosted-fields-cvv'
-            },
-            expirationDate: {
-              selector: '#hosted-fields-expiration-date'
+
+            function validateBillingFields() {
+                var isValid = true;
+
+                Object.keys(billingFields).forEach(function (fieldName) {
+                    var fieldEmpty = false;
+                    var field = billingFields[fieldName];
+
+                    if (field.optional) {
+                        return;
+                    }
+
+                    fieldEmpty = field.input.value.trim() === '';
+
+                    if (fieldEmpty) {
+                        isValid = false;
+                        field.help.innerText = "<%= Spree.t(:required) %>";
+                        field.help.parentNode.classList.add('has-error');
+                    } else {
+                        clearFieldValidations(field);
+                    }
+                });
+
+                return isValid;
             }
-          }
-        }),
-        braintree.threeDSecure.create({
-          authorization: clientToken,
-          version: 2
-        })
-      ]);
-    }
 
-    function setupDropin (clientToken) {
-      return braintree.dropin.create({
-        authorization: clientToken,
-        container: '#drop-in',
-        threeDSecure: true
-      })
-    }
+            function start() {
+                getClientToken();
+            }
 
-    function onFetchClientToken(clientToken) {
-      <% if hosted %>
-      return setupComponents(clientToken).then(function(instances) {
-        hf = instances[0];
-        threeDS = instances[1];
-        <% elsif dropin %>
-        return setupDropin(clientToken).then(function(instance) {
-          dropin = instance;
-          <% end %>
+            function getClientToken() {
+                onFetchClientToken(clientToken);
+            }
 
-          setupForm();
-        }).catch(function (err) {
-          console.log('component error:', err);
-        });
-      }
+            function setupComponents (clientToken) {
+                return Promise.all([
+                    braintree.hostedFields.create({
+                        authorization: clientToken,
+                        styles: {
+                            input: {
+                                'font-size': '14px',
+                                'font-family': 'monospace'
+                            }
+                        },
+                        fields: {
+                            number: {
+                                selector: '#hosted-fields-number'
+                            },
+                            cvv: {
+                                selector: '#hosted-fields-cvv'
+                            },
+                            expirationDate: {
+                                selector: '#hosted-fields-expiration-date'
+                            }
+                        }
+                    }),
+                    braintree.threeDSecure.create({
+                        authorization: clientToken,
+                        version: 2
+                    })
+                ]);
+            }
 
-      function setupForm() {
-        enablePayNow();
-      }
+            function setupDropin (clientToken) {
+                return braintree.dropin.create({
+                    authorization: clientToken,
+                    container: '#drop-in',
+                    threeDSecure: true
+                })
+            }
 
-      function enablePayNow() {
-        payBtn.value = "<%= Spree.t(:save_and_continue) %>";
-        payBtn.removeAttribute('disabled');
-      }
-
-      function showErrors() {
-        payGroup.addClass('hidden');
-        payGroup.css('display', 'none');
-        $('.credit-card-pay-success').addClass('hidden')
-        $('.credit-card-pay-errors').removeClass('hidden')
-      }
-
-      function showSuccess() {
-        payGroup.addClass('hidden');
-        payGroup.css('display', 'none');
-        <% if hosted %>
-        hostedFieldsContainer.style.display = 'none';
-        <% end %>
-        $('.credit-card-pay-errors').addClass('hidden')
-        $('.credit-card-pay-success').removeClass('hidden')
-      }
-
-      payBtn.addEventListener('click', function(event) {
-        event.preventDefault()
-        payBtn.setAttribute('disabled', 'disabled');
-        payBtn.value = "<%= Spree.t(:processing_credit_card) %>";
-
-        var billingIsValid = validateBillingFields();
-
-        if (!billingIsValid) {
-          enablePayNow();
-
-          return;
-        }
-        <% if hosted %>
-        hf.tokenize().then(function (payload) {
-          return threeDS.verifyCard({
-            onLookupComplete: function (data, next) {
-              next();
-            },
-            nonce: payload.nonce,
-            bin: payload.details.bin,
-            <% elsif dropin %>
-            dropin.requestPaymentMethod({
-              threeDSecure: {
-                <% end %>
-                amount: "<%= @order.total %>",
-                email: billingFields.email.input.value,
+            function onFetchClientToken(clientToken) {
                 <% if hosted %>
-              })
-          }).then(function (payload) {
-            <% elsif dropin %>
-          }
-        }, function(err, payload) {
-          if (err) {
-            console.log('tokenization error:');
-            console.log(err);
-            dropin.clearSelectedPaymentMethod();
-            enablePayNow();
+                return setupComponents(clientToken).then(function(instances) {
+                    hf = instances[0];
+                    threeDS = instances[1];
+                    <% elsif dropin %>
+                    return setupDropin(clientToken).then(function(instance) {
+                        dropin = instance;
+                        <% end %>
 
-            return;
-          }
-          <% end %>
+                        setupForm();
+                    }).catch(function (err) {
+                        console.log('component error:', err);
+                    });
+                }
 
-          if (!payload.liabilityShifted) {
-            console.log('Liability did not shift', payload);
-            showErrors();
-            return;
-          }
+                function setupForm() {
+                    enablePayNow();
+                }
 
-          console.log('verification success:', payload);
-          showSuccess();
-          $(formId).append("<input type='hidden' name='braintree_last_two' value=" + payload.details.lastTwo + ">");
-          $(formId).append("<input type='hidden' name='braintree_card_type' value=" + payload.details.cardType.replace(/\s/g, "") + ">");
-          $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
-          $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
-          setTimeout(function () {
-            $('.checkout-btn').attr("disabled", false)
-            $('form.edit_order').submit()
-          }, 200);
-          <% if hosted %>
-        }).catch(function (err) {
-          enablePayNow();
-          showErrors();
-          <% end %>
-        });
-      });
+                function enablePayNow() {
+                    payBtn.value = "<%= Spree.t(:save_and_continue) %>";
+                    payBtn.removeAttribute('disabled');
+                }
 
-      start();
+                function showErrors() {
+                    payGroup.addClass('hidden');
+                    payGroup.css('display', 'none');
+                    $('.credit-card-pay-success').addClass('hidden')
+                    $('.credit-card-pay-errors').removeClass('hidden')
+                }
+
+                function showSuccess() {
+                    payGroup.addClass('hidden');
+                    payGroup.css('display', 'none');
+                    <% if hosted %>
+                    hostedFieldsContainer.style.display = 'none';
+                    <% end %>
+                    $('.credit-card-pay-errors').addClass('hidden')
+                    $('.credit-card-pay-success').removeClass('hidden')
+                }
+
+                payBtn.addEventListener('click', function(event) {
+                    event.preventDefault()
+                    payBtn.setAttribute('disabled', 'disabled');
+                    payBtn.value = "<%= Spree.t(:processing_credit_card) %>";
+
+                    var billingIsValid = validateBillingFields();
+
+                    if (!billingIsValid) {
+                        enablePayNow();
+
+                        return;
+                    }
+                    <% if hosted %>
+                    hf.tokenize().then(function (payload) {
+                        return threeDS.verifyCard({
+                            onLookupComplete: function (data, next) {
+                                next();
+                            },
+                            nonce: payload.nonce,
+                            bin: payload.details.bin,
+                            <% elsif dropin %>
+                            dropin.requestPaymentMethod({
+                                threeDSecure: {
+                                    <% end %>
+                                    amount: "<%= @order.total %>",
+                                    email: billingFields.email.input.value,
+                                    <% if hosted %>
+                                })
+                        }).then(function (payload) {
+                            <% elsif dropin %>
+                        }
+                    }, function(err, payload) {
+                        if (err) {
+                            console.log('tokenization error:');
+                            console.log(err);
+                            dropin.clearSelectedPaymentMethod();
+                            enablePayNow();
+
+                            return;
+                        }
+                        <% end %>
+
+                        if (!payload.liabilityShifted) {
+                            console.log('Liability did not shift', payload);
+                            showErrors();
+                            return;
+                        }
+
+                        console.log('verification success:', payload);
+                        showSuccess();
+                        $(formId).append("<input type='hidden' name='braintree_last_two' value=" + payload.details.lastTwo + ">");
+                        $(formId).append("<input type='hidden' name='braintree_card_type' value=" + payload.details.cardType.replace(/\s/g, "") + ">");
+                        $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
+                        $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
+                        setTimeout(function () {
+                            $('.checkout-btn').attr("disabled", false)
+                            $('form.edit_order').submit()
+                        }, 200);
+                        <% if hosted %>
+                    }).catch(function (err) {
+                        enablePayNow();
+                        showErrors();
+                        <% end %>
+                    });
+                });
+
+                start();
+            });
     });
 </script>

--- a/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
@@ -10,7 +10,7 @@
       <% if hosted %>
       var hf, threeDS;
       var hostedFieldsContainer = document.getElementById('hosted-fields');
-      <% elsif dropin%>
+      <% elsif dropin %>
       var dropin;
       <% end %>
 

--- a/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
@@ -16,6 +16,10 @@
 
       var payBtn = document.getElementsByName('commit')[0];
       var payGroup = $('.pay-group');
+
+      $('.credit-card-pay-success').css('display', 'none');
+      $('.credit-card-pay-errors').css('display', 'none');
+
       var billingFields = [
         'email',
       ].reduce(function (fields, fieldName) {
@@ -134,8 +138,8 @@
         function showErrors() {
           payGroup.addClass('hidden');
           payGroup.css('display', 'none');
-          $('.credit-card-pay-success').addClass('hidden')
-          $('.credit-card-pay-errors').removeClass('hidden')
+          $('.credit-card-pay-success').css('display', 'none');
+          $('.credit-card-pay-errors').css('display', 'block');
         }
 
         function showSuccess() {
@@ -144,8 +148,8 @@
           <% if hosted %>
           hostedFieldsContainer.style.display = 'none';
           <% end %>
-          $('.credit-card-pay-errors').addClass('hidden')
-          $('.credit-card-pay-success').removeClass('hidden')
+          $('.credit-card-pay-success').css('display', 'block');
+          $('.credit-card-pay-errors').css('display', 'none');
         }
 
         payBtn.addEventListener('click', function(event) {

--- a/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    window.addEventListener('load', function() {
+    window.addEventListener('DOMContentLoaded', function() {
         $('#order_payments_attributes__payment_method_id_<%= payment_method.id %>').click(function (e) {
             var threeDSecure;
             var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
@@ -203,8 +203,8 @@
                         $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
                         $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
                         setTimeout(function () {
-                            $('.checkout-btn').attr("disabled", false)
-                            $('form.edit_order').submit()
+                            $(payBtn).attr("disabled", false)
+                            $('#checkout form').submit()
                         }, 200);
                         <% if hosted %>
                     }).catch(function (err) {

--- a/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
@@ -1,220 +1,220 @@
 <script type="text/javascript">
-    window.addEventListener('DOMContentLoaded', function() {
-        $('#order_payments_attributes__payment_method_id_<%= payment_method.id %>').click(function (e) {
-            var threeDSecure;
-            var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
-            var formId = "#" + checkoutFormId;
+  window.addEventListener('DOMContentLoaded', function() {
+    $('#order_payments_attributes__payment_method_id_<%= payment_method.id %>').click(function (e) {
+      var threeDSecure;
+      var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
+      var formId = "#" + checkoutFormId;
 
-            var clientToken = "<%= payment_method.client_token(@order) %>";
+      var clientToken = "<%= payment_method.client_token(@order) %>";
 
-            <% if hosted %>
-            var hf, threeDS;
-            var hostedFieldsContainer = document.getElementById('hosted-fields');
-            <% elsif dropin%>
-            var dropin;
+      <% if hosted %>
+      var hf, threeDS;
+      var hostedFieldsContainer = document.getElementById('hosted-fields');
+      <% elsif dropin%>
+      var dropin;
+      <% end %>
+
+      var payBtn = document.getElementsByName('commit')[0];
+      var payGroup = $('.pay-group');
+      var billingFields = [
+        'email',
+      ].reduce(function (fields, fieldName) {
+        var field = fields[fieldName] = {
+          input: document.getElementById(fieldName),
+          help: document.getElementById('help-' + fieldName)
+        };
+
+        field.input.addEventListener('focus', function() {
+          clearFieldValidations(field);
+        });
+
+        return fields;
+      }, {});
+
+      function clearFieldValidations (field) {
+        field.help.innerText = '';
+        field.help.parentNode.classList.remove('has-error');
+      }
+
+      function validateBillingFields() {
+        var isValid = true;
+
+        Object.keys(billingFields).forEach(function (fieldName) {
+          var fieldEmpty = false;
+          var field = billingFields[fieldName];
+
+          if (field.optional) {
+            return;
+          }
+
+          fieldEmpty = field.input.value.trim() === '';
+
+          if (fieldEmpty) {
+            isValid = false;
+            field.help.innerText = "<%= Spree.t(:required) %>";
+            field.help.parentNode.classList.add('has-error');
+          } else {
+            clearFieldValidations(field);
+          }
+        });
+
+        return isValid;
+      }
+
+      function start() {
+        getClientToken();
+      }
+
+      function getClientToken() {
+        onFetchClientToken(clientToken);
+      }
+
+      function setupComponents (clientToken) {
+        return Promise.all([
+          braintree.hostedFields.create({
+            authorization: clientToken,
+            styles: {
+              input: {
+                'font-size': '14px',
+                'font-family': 'monospace'
+              }
+            },
+            fields: {
+              number: {
+                selector: '#hosted-fields-number'
+              },
+              cvv: {
+                selector: '#hosted-fields-cvv'
+              },
+              expirationDate: {
+                selector: '#hosted-fields-expiration-date'
+              }
+            }
+          }),
+          braintree.threeDSecure.create({
+            authorization: clientToken,
+            version: 2
+          })
+        ]);
+      }
+
+      function setupDropin (clientToken) {
+        return braintree.dropin.create({
+          authorization: clientToken,
+          container: '#drop-in',
+          threeDSecure: true
+        })
+      }
+
+      function onFetchClientToken(clientToken) {
+        <% if hosted %>
+        return setupComponents(clientToken).then(function(instances) {
+          hf = instances[0];
+          threeDS = instances[1];
+          <% elsif dropin %>
+          return setupDropin(clientToken).then(function(instance) {
+            dropin = instance;
             <% end %>
 
-            var payBtn = document.getElementsByName('commit')[0];
-            var payGroup = $('.pay-group');
-            var billingFields = [
-                'email',
-            ].reduce(function (fields, fieldName) {
-                var field = fields[fieldName] = {
-                    input: document.getElementById(fieldName),
-                    help: document.getElementById('help-' + fieldName)
-                };
+            setupForm();
+          }).catch(function (err) {
+            console.log('component error:', err);
+          });
+        }
 
-                field.input.addEventListener('focus', function() {
-                    clearFieldValidations(field);
-                });
+        function setupForm() {
+          enablePayNow();
+        }
 
-                return fields;
-            }, {});
+        function enablePayNow() {
+          payBtn.value = "<%= Spree.t(:save_and_continue) %>";
+          payBtn.removeAttribute('disabled');
+        }
 
-            function clearFieldValidations (field) {
-                field.help.innerText = '';
-                field.help.parentNode.classList.remove('has-error');
-            }
+        function showErrors() {
+          payGroup.addClass('hidden');
+          payGroup.css('display', 'none');
+          $('.credit-card-pay-success').addClass('hidden')
+          $('.credit-card-pay-errors').removeClass('hidden')
+        }
 
-            function validateBillingFields() {
-                var isValid = true;
+        function showSuccess() {
+          payGroup.addClass('hidden');
+          payGroup.css('display', 'none');
+          <% if hosted %>
+          hostedFieldsContainer.style.display = 'none';
+          <% end %>
+          $('.credit-card-pay-errors').addClass('hidden')
+          $('.credit-card-pay-success').removeClass('hidden')
+        }
 
-                Object.keys(billingFields).forEach(function (fieldName) {
-                    var fieldEmpty = false;
-                    var field = billingFields[fieldName];
+        payBtn.addEventListener('click', function(event) {
+          event.preventDefault()
+          payBtn.setAttribute('disabled', 'disabled');
+          payBtn.value = "<%= Spree.t(:processing_credit_card) %>";
 
-                    if (field.optional) {
-                        return;
-                    }
+          var billingIsValid = validateBillingFields();
 
-                    fieldEmpty = field.input.value.trim() === '';
+          if (!billingIsValid) {
+            enablePayNow();
 
-                    if (fieldEmpty) {
-                        isValid = false;
-                        field.help.innerText = "<%= Spree.t(:required) %>";
-                        field.help.parentNode.classList.add('has-error');
-                    } else {
-                        clearFieldValidations(field);
-                    }
-                });
-
-                return isValid;
-            }
-
-            function start() {
-                getClientToken();
-            }
-
-            function getClientToken() {
-                onFetchClientToken(clientToken);
-            }
-
-            function setupComponents (clientToken) {
-                return Promise.all([
-                    braintree.hostedFields.create({
-                        authorization: clientToken,
-                        styles: {
-                            input: {
-                                'font-size': '14px',
-                                'font-family': 'monospace'
-                            }
-                        },
-                        fields: {
-                            number: {
-                                selector: '#hosted-fields-number'
-                            },
-                            cvv: {
-                                selector: '#hosted-fields-cvv'
-                            },
-                            expirationDate: {
-                                selector: '#hosted-fields-expiration-date'
-                            }
-                        }
-                    }),
-                    braintree.threeDSecure.create({
-                        authorization: clientToken,
-                        version: 2
-                    })
-                ]);
-            }
-
-            function setupDropin (clientToken) {
-                return braintree.dropin.create({
-                    authorization: clientToken,
-                    container: '#drop-in',
-                    threeDSecure: true
+            return;
+          }
+          <% if hosted %>
+          hf.tokenize().then(function (payload) {
+            return threeDS.verifyCard({
+              onLookupComplete: function (data, next) {
+                next();
+              },
+              nonce: payload.nonce,
+              bin: payload.details.bin,
+              <% elsif dropin %>
+              dropin.requestPaymentMethod({
+                threeDSecure: {
+                  <% end %>
+                  amount: "<%= @order.total %>",
+                  email: billingFields.email.input.value,
+                  <% if hosted %>
                 })
+            }).then(function (payload) {
+              <% elsif dropin %>
+            }
+          }, function(err, payload) {
+            if (err) {
+              console.log('tokenization error:');
+              console.log(err);
+              dropin.clearSelectedPaymentMethod();
+              enablePayNow();
+
+              return;
+            }
+            <% end %>
+
+            if (!payload.liabilityShifted) {
+              console.log('Liability did not shift', payload);
+              showErrors();
+              return;
             }
 
-            function onFetchClientToken(clientToken) {
-                <% if hosted %>
-                return setupComponents(clientToken).then(function(instances) {
-                    hf = instances[0];
-                    threeDS = instances[1];
-                    <% elsif dropin %>
-                    return setupDropin(clientToken).then(function(instance) {
-                        dropin = instance;
-                        <% end %>
+            console.log('verification success:', payload);
+            showSuccess();
+            $(formId).append("<input type='hidden' name='braintree_last_two' value=" + payload.details.lastTwo + ">");
+            $(formId).append("<input type='hidden' name='braintree_card_type' value=" + payload.details.cardType.replace(/\s/g, "") + ">");
+            $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
+            $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
+            setTimeout(function () {
+              $(payBtn).attr("disabled", false)
+              $('#checkout form').submit()
+            }, 200);
+            <% if hosted %>
+          }).catch(function (err) {
+            enablePayNow();
+            showErrors();
+            <% end %>
+          });
+        });
 
-                        setupForm();
-                    }).catch(function (err) {
-                        console.log('component error:', err);
-                    });
-                }
-
-                function setupForm() {
-                    enablePayNow();
-                }
-
-                function enablePayNow() {
-                    payBtn.value = "<%= Spree.t(:save_and_continue) %>";
-                    payBtn.removeAttribute('disabled');
-                }
-
-                function showErrors() {
-                    payGroup.addClass('hidden');
-                    payGroup.css('display', 'none');
-                    $('.credit-card-pay-success').addClass('hidden')
-                    $('.credit-card-pay-errors').removeClass('hidden')
-                }
-
-                function showSuccess() {
-                    payGroup.addClass('hidden');
-                    payGroup.css('display', 'none');
-                    <% if hosted %>
-                    hostedFieldsContainer.style.display = 'none';
-                    <% end %>
-                    $('.credit-card-pay-errors').addClass('hidden')
-                    $('.credit-card-pay-success').removeClass('hidden')
-                }
-
-                payBtn.addEventListener('click', function(event) {
-                    event.preventDefault()
-                    payBtn.setAttribute('disabled', 'disabled');
-                    payBtn.value = "<%= Spree.t(:processing_credit_card) %>";
-
-                    var billingIsValid = validateBillingFields();
-
-                    if (!billingIsValid) {
-                        enablePayNow();
-
-                        return;
-                    }
-                    <% if hosted %>
-                    hf.tokenize().then(function (payload) {
-                        return threeDS.verifyCard({
-                            onLookupComplete: function (data, next) {
-                                next();
-                            },
-                            nonce: payload.nonce,
-                            bin: payload.details.bin,
-                            <% elsif dropin %>
-                            dropin.requestPaymentMethod({
-                                threeDSecure: {
-                                    <% end %>
-                                    amount: "<%= @order.total %>",
-                                    email: billingFields.email.input.value,
-                                    <% if hosted %>
-                                })
-                        }).then(function (payload) {
-                            <% elsif dropin %>
-                        }
-                    }, function(err, payload) {
-                        if (err) {
-                            console.log('tokenization error:');
-                            console.log(err);
-                            dropin.clearSelectedPaymentMethod();
-                            enablePayNow();
-
-                            return;
-                        }
-                        <% end %>
-
-                        if (!payload.liabilityShifted) {
-                            console.log('Liability did not shift', payload);
-                            showErrors();
-                            return;
-                        }
-
-                        console.log('verification success:', payload);
-                        showSuccess();
-                        $(formId).append("<input type='hidden' name='braintree_last_two' value=" + payload.details.lastTwo + ">");
-                        $(formId).append("<input type='hidden' name='braintree_card_type' value=" + payload.details.cardType.replace(/\s/g, "") + ">");
-                        $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
-                        $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
-                        setTimeout(function () {
-                            $(payBtn).attr("disabled", false)
-                            $('#checkout form').submit()
-                        }, 200);
-                        <% if hosted %>
-                    }).catch(function (err) {
-                        enablePayNow();
-                        showErrors();
-                        <% end %>
-                    });
-                });
-
-                start();
-            });
-    });
+        start();
+      });
+  });
 </script>

--- a/spec/models/gateway/braintree_vzero_base_spec.rb
+++ b/spec/models/gateway/braintree_vzero_base_spec.rb
@@ -198,7 +198,7 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         gateway.preferred_3dsecure = false
         payment.update(amount: order.reload.total)
         complete_order!
-        order.payments.first.source.update_attributes(transaction_id: 'dw49zp', state: 'authorized') # use already settled transaction
+        order.payments.first.source.update_attribute(:transaction_id, 'dw49zp') # use already settled transaction
       end
 
       let!(:result) { Spree::BraintreeCheckout.update_states }
@@ -244,7 +244,6 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         before do
           payment.update(braintree_nonce: 'fake-paypal-one-time-nonce')
           complete_order!
-          order.payments.first.source.update_attribute(:state, 'settling')
           void
         end
 
@@ -263,7 +262,6 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         gateway.update(auto_capture: false)
         complete_order!
         payment.reload
-        payment.source.update_attributes(transaction_id: 'dw49zp', state: 'authorized')
       end
 
       context 'settles authorized amount' do
@@ -280,9 +278,9 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         end
 
         it 'submits Transaction for settlement' do
-          expect(gateway.provider::Transaction.find(payment.source.transaction_id).status).to eq 'authorized'
+          expect(gateway.provider::Transaction.find(payment.response_code).status).to eq 'authorized'
           payment.reload.settle!
-          expect(gateway.provider::Transaction.find(payment.source.transaction_id).status).to eq 'submitted_for_settlement'
+          expect(gateway.provider::Transaction.find(payment.response_code).status).to eq 'submitted_for_settlement'
         end
 
         it 'prepares Checkout for status updating' do

--- a/spec/models/gateway/braintree_vzero_base_spec.rb
+++ b/spec/models/gateway/braintree_vzero_base_spec.rb
@@ -198,7 +198,7 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         gateway.preferred_3dsecure = false
         payment.update(amount: order.reload.total)
         complete_order!
-        order.payments.first.source.update_attribute(:transaction_id, 'dw49zp') # use already settled transaction
+        order.payments.first.source.update_attributes(transaction_id: 'dw49zp', state: 'authorized') # use already settled transaction
       end
 
       let!(:result) { Spree::BraintreeCheckout.update_states }
@@ -244,6 +244,7 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         before do
           payment.update(braintree_nonce: 'fake-paypal-one-time-nonce')
           complete_order!
+          order.payments.first.source.update_attribute(:state, 'settling')
           void
         end
 
@@ -262,6 +263,7 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         gateway.update(auto_capture: false)
         complete_order!
         payment.reload
+        payment.source.update_attributes(transaction_id: 'dw49zp', state: 'authorized')
       end
 
       context 'settles authorized amount' do
@@ -278,9 +280,9 @@ describe Spree::Gateway::BraintreeVzeroBase, :vcr do
         end
 
         it 'submits Transaction for settlement' do
-          expect(gateway.provider::Transaction.find(payment.response_code).status).to eq 'authorized'
+          expect(gateway.provider::Transaction.find(payment.source.transaction_id).status).to eq 'authorized'
           payment.reload.settle!
-          expect(gateway.provider::Transaction.find(payment.response_code).status).to eq 'submitted_for_settlement'
+          expect(gateway.provider::Transaction.find(payment.source.transaction_id).status).to eq 'submitted_for_settlement'
         end
 
         it 'prepares Checkout for status updating' do


### PR DESCRIPTION
fixes: https://github.com/spree-contrib/spree_braintree_vzero/issues/214
- Due to the validation in spree: https://github.com/spree/spree/commit/1e9cc61f803fec203839a642f3cc08ba2cbbf4a7 we need to add `source_required?` method in the payment method model.
- Changes in frontend on checkout were not not reflected in BraintreeVZero, the form couldn't render properly and complete payment creation on payment step
- Modified `handle_payment_preconditions` in payment processing decorator (added `yield` for payment methods with Braintree as a provider) so the authorization and purchase actions can be performed on payment methods with `source_required? false`.
- Modified the views so the success/error messages are visible only after the process is completed

**Current status:**
Checkout can be completed via _HostedFields_ and _DropIn_, payment and source info seems to be valid. There's possibility for minor issues that can affect the checkout flow but it would need further testing
**Make sure your version of `spree_gateway` includes this commit** https://github.com/spree/spree_gateway/commit/5a7bc087fbd96981723c240a564c53443d9780c2

**Known issues**
After failed verification there is wrong name of the "Pay" button and form mostly disappears. Preferably, the app should reload the page (and show the notification about incorrect verification) or every checkout element should be still operable (so the User can complete the payment step without refreshing)

**PayPal Express testing**
(This needs verification)
Paypal Express was not designed to be chosen on `Payment` step. The current design expects the User to select "Paypal" button in the Cart. After going through the js and view files it seems like it was the only designed way to use paypal express. Because of that, make sure that the PaypalExpress payment method is set to `Backend` - this way, the paypal button will be visible in the cart but there's no additional payment method to choose on payment step.