### PR TITLE
after_save callbacks - patch for Rails < 5.2 apps

### DIFF
--- a/app/models/concerns/spree/gateway/braintree_vzero/legacy_rails_patch.rb
+++ b/app/models/concerns/spree/gateway/braintree_vzero/legacy_rails_patch.rb
@@ -1,0 +1,20 @@
+module Spree
+  class Gateway
+    module BraintreeVzero
+      module LegacyRailsPatch
+        extend ActiveSupport::Concern
+
+        private
+
+        # https://github.com/spree-contrib/spree_braintree_vzero/issues/216
+        def method_name_for_attributes_after_save
+          Rails::VERSION::STRING >= '5.1' ? :saved_changes : :changes
+        end
+
+        def attributes_after_save
+          method(method_name_for_attributes_after_save).call
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/gateway/braintree_vzero_drop_in_ui.rb
+++ b/app/models/spree/gateway/braintree_vzero_drop_in_ui.rb
@@ -1,5 +1,7 @@
 module Spree
   class Gateway::BraintreeVzeroDropInUi < Spree::Gateway::BraintreeVzeroBase
+    include BraintreeVzero::LegacyRailsPatch
+
     preference :dropin_container, :string, default: 'payment-form'
     preference :checkout_form_id, :string, default: 'checkout_form_payment'
     preference :error_messages_container_id, :string, default: 'content'
@@ -7,7 +9,7 @@ module Spree
     preference :'3dsecure', :boolean_select, default: false
 
     after_save :disable_hosted_gateways, if: proc {
-      active? && (saved_changes.keys & %w[active id]).any?
+      active? && (attributes_after_save.keys & %w[active id]).any?
     }
 
     def method_type

--- a/app/models/spree/gateway/braintree_vzero_hosted_fields.rb
+++ b/app/models/spree/gateway/braintree_vzero_hosted_fields.rb
@@ -1,5 +1,7 @@
 module Spree
   class Gateway::BraintreeVzeroHostedFields < Spree::Gateway::BraintreeVzeroBase
+    include BraintreeVzero::LegacyRailsPatch
+
     preference :checkout_form_id, :string, default: 'checkout_form_payment'
     preference :error_messages_container_id, :string, default: 'content'
     preference :number_selector, :string, default: '#hosted-fields-number'
@@ -12,7 +14,7 @@ module Spree
     preference :'3dsecure', :boolean_select, default: false
 
     after_save :disable_dropin_gateways, if: proc {
-      active? && (saved_changes.keys & %w[active id]).any?
+      active? && (attributes_after_save.keys & %w[active id]).any?
     }
 
     def method_type


### PR DESCRIPTION
fixes #216


Alternatively, we could provide separate dedicated gem versions, one for `Rails < 5.2 (Spree < 3.6)` and another one for `Rails >= 5.2 (Spree >= 3.6)`