### PR TITLE
Add missing helpers to payments controller fix

### DIFF
--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -1,47 +1,43 @@
-module Spree
-  module Admin
-    module PaymentsControllerDecorator
-      def self.prepended(base)
-        base.helper_method [:asset_available?, :options_from_braintree_payments]
-      end
+module Spree::Admin::UniqPaymentsControllerDecorator
+  def self.prepended(base)
+    base.helper_method [:asset_available?, :options_from_braintree_payments]
+  end
 
-      def create
-        invoke_callbacks(:create, :before)
-        @payment ||= @order.payments.build(object_params)
-        # not only credit card may require source
-        if @payment.payment_method.source_required?
-          if params[:card].present? && params[:card] != 'new'
-            @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
-          elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-            @payment.braintree_token = params[:payment_method_token]
-            @payment.braintree_nonce = params[:payment_method_nonce]
-            @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
-          end
-        end
-
-        begin
-          if @payment.save
-            invoke_callbacks(:create, :after)
-            # Transition order as far as it will go.
-            while @order.next; end
-            # If "@order.next" didn't trigger payment processing already (e.g. if the order was
-            # already complete) then trigger it manually now
-            @payment.process! if @order.completed? && @payment.checkout?
-            flash[:success] = flash_message_for(@payment, :successfully_created)
-            redirect_to admin_order_payments_path(@order)
-          else
-            invoke_callbacks(:create, :fails)
-            flash[:error] = Spree.t(:payment_could_not_be_created)
-            render :new
-          end
-        rescue Spree::Core::GatewayError => e
-          invoke_callbacks(:create, :fails)
-          flash[:error] = e.message.to_s
-          redirect_to new_admin_order_payment_path(@order)
-        end
+  def create
+    invoke_callbacks(:create, :before)
+    @payment ||= @order.payments.build(object_params)
+    # not only credit card may require source
+    if @payment.payment_method.source_required?
+      if params[:card].present? && params[:card] != 'new'
+        @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
+      elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+        @payment.braintree_token = params[:payment_method_token]
+        @payment.braintree_nonce = params[:payment_method_nonce]
+        @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
       end
+    end
+
+    begin
+      if @payment.save
+        invoke_callbacks(:create, :after)
+        # Transition order as far as it will go.
+        while @order.next; end
+        # If "@order.next" didn't trigger payment processing already (e.g. if the order was
+        # already complete) then trigger it manually now
+        @payment.process! if @order.completed? && @payment.checkout?
+        flash[:success] = flash_message_for(@payment, :successfully_created)
+        redirect_to admin_order_payments_path(@order)
+      else
+        invoke_callbacks(:create, :fails)
+        flash[:error] = Spree.t(:payment_could_not_be_created)
+        render :new
+      end
+    rescue Spree::Core::GatewayError => e
+      invoke_callbacks(:create, :fails)
+      flash[:error] = e.message.to_s
+      redirect_to new_admin_order_payment_path(@order)
     end
   end
 end
 
-::Spree::Admin::PaymentsController.prepend(Spree::Admin::PaymentsControllerDecorator)
+::Spree::Admin::PaymentsController.prepend(Spree::Admin::UniqPaymentsControllerDecorator)

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -1,5 +1,6 @@
 module Spree::Admin::UniqPaymentsControllerDecorator
   def self.prepended(base)
+    base.include Spree::BraintreeHelper
     base.helper_method [:asset_available?, :options_from_braintree_payments]
   end
 

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -1,44 +1,48 @@
-module Spree::Admin::UniqPaymentsControllerDecorator
-  def self.prepended(base)
-    base.include Spree::BraintreeHelper
-    base.helper_method [:asset_available?, :options_from_braintree_payments]
-  end
-
-  def create
-    invoke_callbacks(:create, :before)
-    @payment ||= @order.payments.build(object_params)
-    # not only credit card may require source
-    if @payment.payment_method.source_required?
-      if params[:card].present? && params[:card] != 'new'
-        @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
-      elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
-        @payment.braintree_token = params[:payment_method_token]
-        @payment.braintree_nonce = params[:payment_method_nonce]
-        @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
+module Spree
+  module Admin
+    module PaymentsControllerDecorator
+      def self.prepended(base)
+        base.include Spree::BraintreeHelper
+        base.helper_method [:asset_available?, :options_from_braintree_payments]
       end
-    end
 
-    begin
-      if @payment.save
-        invoke_callbacks(:create, :after)
-        # Transition order as far as it will go.
-        while @order.next; end
-        # If "@order.next" didn't trigger payment processing already (e.g. if the order was
-        # already complete) then trigger it manually now
-        @payment.process! if @order.completed? && @payment.checkout?
-        flash[:success] = flash_message_for(@payment, :successfully_created)
-        redirect_to admin_order_payments_path(@order)
-      else
-        invoke_callbacks(:create, :fails)
-        flash[:error] = Spree.t(:payment_could_not_be_created)
-        render :new
+      def create
+        invoke_callbacks(:create, :before)
+        @payment ||= @order.payments.build(object_params)
+        # not only credit card may require source
+        if @payment.payment_method.source_required?
+          if params[:card].present? && params[:card] != 'new'
+            @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
+          elsif @payment.payment_source.is_a?(Spree::Gateway::BraintreeVzeroBase)
+            @payment.braintree_token = params[:payment_method_token]
+            @payment.braintree_nonce = params[:payment_method_nonce]
+            @payment.source = Spree::BraintreeCheckout.create!(admin_payment: true)
+          end
+        end
+
+        begin
+          if @payment.save
+            invoke_callbacks(:create, :after)
+            # Transition order as far as it will go.
+            while @order.next; end
+            # If "@order.next" didn't trigger payment processing already (e.g. if the order was
+            # already complete) then trigger it manually now
+            @payment.process! if @order.completed? && @payment.checkout?
+            flash[:success] = flash_message_for(@payment, :successfully_created)
+            redirect_to admin_order_payments_path(@order)
+          else
+            invoke_callbacks(:create, :fails)
+            flash[:error] = Spree.t(:payment_could_not_be_created)
+            render :new
+          end
+        rescue Spree::Core::GatewayError => e
+          invoke_callbacks(:create, :fails)
+          flash[:error] = e.message.to_s
+          redirect_to new_admin_order_payment_path(@order)
+        end
       end
-    rescue Spree::Core::GatewayError => e
-      invoke_callbacks(:create, :fails)
-      flash[:error] = e.message.to_s
-      redirect_to new_admin_order_payment_path(@order)
     end
   end
 end
 
-::Spree::Admin::PaymentsController.prepend(Spree::Admin::UniqPaymentsControllerDecorator)
+::Spree::Admin::PaymentsController.prepend(Spree::Admin::PaymentsControllerDecorator)


### PR DESCRIPTION
Fix for https://github.com/spree-contrib/spree_braintree_vzero/pull/234
Included missing module which contains helper methods added in [previous](https://github.com/spree-contrib/spree_braintree_vzero/pull/234) PR, like [here](https://github.com/spree-contrib/spree_braintree_vzero/blob/841127e1528e05674a99644966357563fb0d6f2e/app/controllers/spree/checkout_controller_decorator.rb#L4) or [here](https://github.com/spree-contrib/spree_braintree_vzero/blob/841127e1528e05674a99644966357563fb0d6f2e/app/controllers/spree/orders_controller_decorator.rb#L4)