### PR TITLE
Fix SpreeBraintreeVzero loading issues

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_braintree_vzero.js
+++ b/app/assets/javascripts/spree/frontend/spree_braintree_vzero.js
@@ -46,7 +46,8 @@ SpreeBraintreeVzero = {
   }
 }
 
-$(document).ready(function() {
+$(document).ready(function () {
+  var event = new Event('spreebraintree:ready');
   paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
     SpreeBraintreeVzero.setSaveAndContinueVisibility();
   });
@@ -65,4 +66,5 @@ $(document).ready(function() {
     SpreeBraintreeVzero.addDeviceData();
   });
   SpreeBraintreeVzero.setSaveAndContinueVisibility();
+  window.dispatchEvent(event);
 })

--- a/app/views/spree/braintree_vzero/_paypal_checkout.html.erb
+++ b/app/views/spree/braintree_vzero/_paypal_checkout.html.erb
@@ -9,7 +9,7 @@
 
   <script type="text/javascript">
     // TODO: Investiagate what kind of checkout (if any) steps should be included during paypal express payment
-    window.addEventListener('DOMContentLoaded', function() {
+    function setupBraintreePayPal() {
       var checkoutFormId = '#update-cart';
       var checkout;
       SpreeBraintreeVzero.checkoutFormId = '#update-cart';
@@ -82,6 +82,22 @@
         }
       });
       document.querySelector('#btnOpenFlow').addEventListener('click', function () { checkout.paypal.initAuthFlow(); }, false);
-    });
+    }
+
+    if(document.readyState !== 'loading') {
+      initBraintreePayPal()
+    } else {
+      window.addEventListener('DOMContentLoaded', initBraintreePayPal);
+    }
+
+    function initBraintreePayPal() {
+      if (typeof SpreeBraintreeVzero === "undefined") {
+        window.addEventListener('spreebraintree:ready', setupBraintreePayPal)
+      }
+      else {
+        setupBraintreePayPal()
+      }
+    }
+
   </script>
 <% end %>

--- a/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
+++ b/app/views/spree/checkout/payment/braintree_vzero/_three_d_secure.html.erb
@@ -1,252 +1,258 @@
 <script type="text/javascript">
-  window.addEventListener('DOMContentLoaded', function() {
+  if(document.readyState !== 'loading') {
+    setupThreeDSecure()
+  } else {
+    window.addEventListener('DOMContentLoaded', setupThreeDSecure);
+  }
+
+  function setupThreeDSecure() {
     $('#order_payments_attributes__payment_method_id_<%= payment_method.id %>').click(function (e) {
-      var threeDSecure;
-      var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
-      var formId = "#" + checkoutFormId;
+    var threeDSecure;
+    var checkoutFormId = "<%= payment_method.preferred_checkout_form_id %>"
+    var formId = "#" + checkoutFormId;
 
-      var clientToken = "<%= payment_method.client_token(@order) %>";
+    var clientToken = "<%= payment_method.client_token(@order) %>";
 
-      <% if hosted %>
-      var hf, threeDS;
-      var hostedFieldsContainer = document.getElementById('hosted-fields');
-      <% elsif dropin %>
-      var dropin;
-      <% end %>
+    <% if hosted %>
+    var hf, threeDS;
+    var hostedFieldsContainer = document.getElementById('hosted-fields');
+    <% elsif dropin %>
+    var dropin;
+    <% end %>
 
-      var payBtn = document.getElementsByName('commit')[0];
-      var payGroup = $('.pay-group');
+    var payBtn = document.getElementsByName('commit')[0];
+    var payGroup = $('.pay-group');
 
-      $('.credit-card-pay-success').css('display', 'none');
-      $('.credit-card-pay-errors').css('display', 'none');
+    $('.credit-card-pay-success').css('display', 'none');
+    $('.credit-card-pay-errors').css('display', 'none');
 
-      var billingFields = [
-        'email',
-      ].reduce(function (fields, fieldName) {
-        var field = fields[fieldName] = {
-          input: document.getElementById(fieldName),
-          help: document.getElementById('help-' + fieldName)
-        };
+    var billingFields = [
+      'email',
+    ].reduce(function (fields, fieldName) {
+      var field = fields[fieldName] = {
+        input: document.getElementById(fieldName),
+        help: document.getElementById('help-' + fieldName)
+      };
 
-        field.input.addEventListener('focus', function() {
-          clearFieldValidations(field);
-        });
-
-        return fields;
-      }, {});
-
-      function clearFieldValidations (field) {
-        field.help.innerText = '';
-        field.help.parentNode.classList.remove('has-error');
-      }
-
-      function validateBillingFields() {
-        var isValid = true;
-
-        Object.keys(billingFields).forEach(function (fieldName) {
-          var fieldEmpty = false;
-          var field = billingFields[fieldName];
-
-          if (field.optional) {
-            return;
-          }
-
-          fieldEmpty = field.input.value.trim() === '';
-
-          if (fieldEmpty) {
-            isValid = false;
-            field.help.innerText = "<%= Spree.t(:required) %>";
-            field.help.parentNode.classList.add('has-error');
-          } else {
-            clearFieldValidations(field);
-          }
-        });
-
-        return isValid;
-      }
-
-      function start() {
-        getClientToken();
-      }
-
-      function getClientToken() {
-        onFetchClientToken(clientToken);
-      }
-
-      function setupComponents (clientToken) {
-        return Promise.all([
-          braintree.hostedFields.create({
-            authorization: clientToken,
-            styles: {
-              input: {
-                'font-size': '14px',
-                'font-family': 'monospace'
-              }
-            },
-            fields: {
-              number: {
-                <% if payment_method.respond_to?(:preferred_number_selector) && payment_method.preferred_number_selector.present? %>
-                  selector: "<%= payment_method.preferred_number_selector %>"
-                <% else %>
-                  selector: '#hosted-fields-number'
-                <% end %>
-              },
-              cvv: {
-                <% if payment_method.respond_to?(:preferred_cvv_selector) && payment_method.preferred_cvv_selector.present? %>
-                  selector: "<%= payment_method.preferred_cvv_selector %>"
-                <% else %>
-                  selector: '#hosted-fields-cvv'
-                <% end %>
-              },
-              expirationDate: {
-                <% if payment_method.respond_to?(:preferred_expiration_date_selector) && payment_method.preferred_expiration_date_selector.present? %>
-                  selector: "<%= payment_method.preferred_expiration_date_selector %>"
-                <% else %>
-                  selector: '#hosted-fields-expiration-date'
-                <% end %>
-              }
-            }
-          }),
-          braintree.threeDSecure.create({
-            authorization: clientToken,
-            version: 2
-          })
-        ]);
-      }
-
-      function setupDropin (clientToken) {
-        return braintree.dropin.create({
-          authorization: clientToken,
-          container: '#drop-in',
-          threeDSecure: true
-        })
-      }
-
-      function onFetchClientToken(clientToken) {
-        <% if hosted %>
-        return setupComponents(clientToken).then(function(instances) {
-          hf = instances[0];
-          threeDS = instances[1];
-          <% elsif dropin %>
-          return setupDropin(clientToken).then(function(instance) {
-            dropin = instance;
-            <% end %>
-
-            setupForm();
-          }).catch(function (err) {
-            console.log('component error:', err);
-          });
-        }
-
-        function setupForm() {
-          enablePayNow();
-        }
-
-        function enablePayNow() {
-          payBtn.value = "<%= Spree.t(:save_and_continue) %>";
-          payBtn.removeAttribute('disabled');
-        }
-
-        function showErrors(err) {
-          if (err) {
-            if (err.details && err.details.invalidFields) {
-              const invalidFields = []
-              Object.keys(err.details.invalidFields).forEach(function (key) {
-                if (key === "expirationDate") {
-                  invalidFields.push("expiration")
-                } else {
-                  invalidFields.push(key)
-                }
-              })
-              const errorString = invalidFields.join(", ")
-              const linkingVerb = invalidFields.length > 1 ? "are" : "is"
-
-              $('.credit-card-pay-errors').text("Card " + errorString + " " + linkingVerb + " incorrect.")
-            }
-          }
-          payGroup.addClass('hidden');
-          payGroup.css('display', 'none');
-          $('.credit-card-pay-success').css('display', 'none');
-          $('.credit-card-pay-errors').css('display', 'block');
-        }
-
-        function showSuccess() {
-          payGroup.addClass('hidden');
-          payGroup.css('display', 'none');
-          <% if hosted %>
-          hostedFieldsContainer.style.display = 'none';
-          <% end %>
-          $('.credit-card-pay-success').css('display', 'block');
-          $('.credit-card-pay-errors').css('display', 'none');
-        }
-
-        payBtn.addEventListener('click', function(event) {
-          event.preventDefault()
-          payBtn.setAttribute('disabled', 'disabled');
-          payBtn.value = "<%= Spree.t(:processing_credit_card) %>";
-
-          var billingIsValid = validateBillingFields();
-
-          if (!billingIsValid) {
-            enablePayNow();
-
-            return;
-          }
-          <% if hosted %>
-          hf.tokenize().then(function (payload) {
-            return threeDS.verifyCard({
-              onLookupComplete: function (data, next) {
-                next();
-              },
-              nonce: payload.nonce,
-              bin: payload.details.bin,
-              <% elsif dropin %>
-              dropin.requestPaymentMethod({
-                threeDSecure: {
-                  <% end %>
-                  amount: "<%= @order.total %>",
-                  email: billingFields.email.input.value,
-                  <% if hosted %>
-                })
-            }).then(function (payload) {
-              <% elsif dropin %>
-            }
-          }, function(err, payload) {
-            if (err) {
-              console.log('tokenization error:');
-              console.log(err);
-              dropin.clearSelectedPaymentMethod();
-              enablePayNow();
-
-              return;
-            }
-            <% end %>
-
-            if (!payload.liabilityShifted) {
-              console.log('Liability did not shift', payload);
-              showErrors();
-              return;
-            }
-
-            console.log('verification success:', payload);
-            showSuccess();
-            $(formId).append("<input type='hidden' name='braintree_last_two' value=" + payload.details.lastTwo + ">");
-            $(formId).append("<input type='hidden' name='braintree_card_type' value=" + payload.details.cardType.replace(/\s/g, "") + ">");
-            $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
-            $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
-            setTimeout(function () {
-              $(payBtn).attr("disabled", false)
-              $('#checkout form').submit()
-            }, 200);
-            <% if hosted %>
-          }).catch(function (err) {
-            enablePayNow();
-            showErrors(err);
-            <% end %>
-          });
-        });
-
-        start();
+      field.input.addEventListener('focus', function() {
+        clearFieldValidations(field);
       });
-  });
+
+      return fields;
+    }, {});
+
+    function clearFieldValidations (field) {
+      field.help.innerText = '';
+      field.help.parentNode.classList.remove('has-error');
+    }
+
+    function validateBillingFields() {
+      var isValid = true;
+
+      Object.keys(billingFields).forEach(function (fieldName) {
+        var fieldEmpty = false;
+        var field = billingFields[fieldName];
+
+        if (field.optional) {
+          return;
+        }
+
+        fieldEmpty = field.input.value.trim() === '';
+
+        if (fieldEmpty) {
+          isValid = false;
+          field.help.innerText = "<%= Spree.t(:required) %>";
+          field.help.parentNode.classList.add('has-error');
+        } else {
+          clearFieldValidations(field);
+        }
+      });
+
+      return isValid;
+    }
+
+    function start() {
+      getClientToken();
+    }
+
+    function getClientToken() {
+      onFetchClientToken(clientToken);
+    }
+
+    function setupComponents (clientToken) {
+      return Promise.all([
+        braintree.hostedFields.create({
+          authorization: clientToken,
+          styles: {
+            input: {
+              'font-size': '14px',
+              'font-family': 'monospace'
+            }
+          },
+          fields: {
+            number: {
+              <% if payment_method.respond_to?(:preferred_number_selector) && payment_method.preferred_number_selector.present? %>
+                selector: "<%= payment_method.preferred_number_selector %>"
+              <% else %>
+                selector: '#hosted-fields-number'
+              <% end %>
+            },
+            cvv: {
+              <% if payment_method.respond_to?(:preferred_cvv_selector) && payment_method.preferred_cvv_selector.present? %>
+                selector: "<%= payment_method.preferred_cvv_selector %>"
+              <% else %>
+                selector: '#hosted-fields-cvv'
+              <% end %>
+            },
+            expirationDate: {
+              <% if payment_method.respond_to?(:preferred_expiration_date_selector) && payment_method.preferred_expiration_date_selector.present? %>
+                selector: "<%= payment_method.preferred_expiration_date_selector %>"
+              <% else %>
+                selector: '#hosted-fields-expiration-date'
+              <% end %>
+            }
+          }
+        }),
+        braintree.threeDSecure.create({
+          authorization: clientToken,
+          version: 2
+        })
+      ]);
+    }
+
+    function setupDropin (clientToken) {
+      return braintree.dropin.create({
+        authorization: clientToken,
+        container: '#drop-in',
+        threeDSecure: true
+      })
+    }
+
+    function onFetchClientToken(clientToken) {
+      <% if hosted %>
+      return setupComponents(clientToken).then(function(instances) {
+        hf = instances[0];
+        threeDS = instances[1];
+        <% elsif dropin %>
+        return setupDropin(clientToken).then(function(instance) {
+          dropin = instance;
+          <% end %>
+
+          setupForm();
+        }).catch(function (err) {
+          console.log('component error:', err);
+        });
+      }
+
+      function setupForm() {
+        enablePayNow();
+      }
+
+      function enablePayNow() {
+        payBtn.value = "<%= Spree.t(:save_and_continue) %>";
+        payBtn.removeAttribute('disabled');
+      }
+
+      function showErrors(err) {
+        if (err) {
+          if (err.details && err.details.invalidFields) {
+            const invalidFields = []
+            Object.keys(err.details.invalidFields).forEach(function (key) {
+              if (key === "expirationDate") {
+                invalidFields.push("expiration")
+              } else {
+                invalidFields.push(key)
+              }
+            })
+            const errorString = invalidFields.join(", ")
+            const linkingVerb = invalidFields.length > 1 ? "are" : "is"
+
+            $('.credit-card-pay-errors').text("Card " + errorString + " " + linkingVerb + " incorrect.")
+          }
+        }
+        payGroup.addClass('hidden');
+        payGroup.css('display', 'none');
+        $('.credit-card-pay-success').css('display', 'none');
+        $('.credit-card-pay-errors').css('display', 'block');
+      }
+
+      function showSuccess() {
+        payGroup.addClass('hidden');
+        payGroup.css('display', 'none');
+        <% if hosted %>
+        hostedFieldsContainer.style.display = 'none';
+        <% end %>
+        $('.credit-card-pay-success').css('display', 'block');
+        $('.credit-card-pay-errors').css('display', 'none');
+      }
+
+      payBtn.addEventListener('click', function(event) {
+        event.preventDefault()
+        payBtn.setAttribute('disabled', 'disabled');
+        payBtn.value = "<%= Spree.t(:processing_credit_card) %>";
+
+        var billingIsValid = validateBillingFields();
+
+        if (!billingIsValid) {
+          enablePayNow();
+
+          return;
+        }
+        <% if hosted %>
+        hf.tokenize().then(function (payload) {
+          return threeDS.verifyCard({
+            onLookupComplete: function (data, next) {
+              next();
+            },
+            nonce: payload.nonce,
+            bin: payload.details.bin,
+            <% elsif dropin %>
+            dropin.requestPaymentMethod({
+              threeDSecure: {
+                <% end %>
+                amount: "<%= @order.total %>",
+                email: billingFields.email.input.value,
+                <% if hosted %>
+              })
+          }).then(function (payload) {
+            <% elsif dropin %>
+          }
+        }, function(err, payload) {
+          if (err) {
+            console.log('tokenization error:');
+            console.log(err);
+            dropin.clearSelectedPaymentMethod();
+            enablePayNow();
+
+            return;
+          }
+          <% end %>
+
+          if (!payload.liabilityShifted) {
+            console.log('Liability did not shift', payload);
+            showErrors();
+            return;
+          }
+
+          console.log('verification success:', payload);
+          showSuccess();
+          $(formId).append("<input type='hidden' name='braintree_last_two' value=" + payload.details.lastTwo + ">");
+          $(formId).append("<input type='hidden' name='braintree_card_type' value=" + payload.details.cardType.replace(/\s/g, "") + ">");
+          $(formId).append("<input type='hidden' name='order[payments_attributes][][braintree_nonce]' value=" + payload.nonce + ">");
+          $(formId).append("<input type='hidden' name='payment_method_nonce' value=" + payload.nonce + ">");
+          setTimeout(function () {
+            $(payBtn).attr("disabled", false)
+            $('#checkout form').submit()
+          }, 200);
+          <% if hosted %>
+        }).catch(function (err) {
+          enablePayNow();
+          showErrors(err);
+          <% end %>
+        });
+      });
+
+      start();
+    });
+  }
 </script>


### PR DESCRIPTION
This PR is fixing the `ReferenceError: Can't find variable: SpreeBraintreeVzero` issue. Also, it fixes the issue when you can't click the `Pay with PayPal` button, by waiting for the document to load first.

I am not using the `turbolinks:load` event because this event triggers multiple times in the site (because it triggers for the original document and for each cached version) and there is no easy way around it.

I was worried about `addEventListener` with the `click` because sometimes this script runes twice, but I totally forgot that the browser will not add another event with the same function and the same `capture` setting.

Closes #228