### PR TITLE
Drop whenever dependency

### DIFF
--- a/spree_braintree_vzero.gemspec
+++ b/spree_braintree_vzero.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_extension'
   s.add_dependency 'braintree', '>= 2.40.0'
   s.add_dependency 'deface', '~> 1.0'
-  s.add_dependency 'whenever'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
It's optional, not required