### PR TITLE
Add line items for paypal integration

### DIFF
--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -136,14 +136,7 @@ module Spree
         end
 
         def order_discount
-          @order
-            .line_item_adjustments
-            .nonzero
-            .promotion
-            .eligible
-            .reject { |a| a.source.promotion.discount? }
-            .sum(&:amount)
-            .to_s
+          @order.adjustment_total.abs.to_s
         end
       end
     end

--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -124,8 +124,8 @@ module Spree
               unit_of_measure: 'unit',
               product_code: li.sku,
               total_amount: li.pre_tax_amount.to_s,
-              tax_amount: li.additional_tax_total.to_s
-              # discount_amount: '0.00'
+              tax_amount: li.additional_tax_total.to_s,
+              discount_amount: li.adjustment_total.abs.to_s
             }
           end.take(PAYPAL_MAX_LINEITEMS)
         end

--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -111,6 +111,11 @@ module Spree
 
         PAYPAL_MAX_LINEITEMS = 249
 
+        # Because of strange PayPal behaviour with accepting discounts
+        # the only solution to add needed discount (if it exist) to
+        # create a virtual Line Item with discount amount and with 'credit'
+        # and name it as 'discount' to be reflected in PayPal email to customer
+        #
         def collect_line_items # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           items =
             @order

--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -39,6 +39,7 @@ module Spree
         def order_data(identifier, amount)
           identifier.merge(
             amount: amount,
+            discount_amount: order_discount,
             order_id: order.number,
             line_items: collect_line_items,
             shipping_amount: order_shipping
@@ -132,6 +133,17 @@ module Spree
 
         def order_shipping
           @order.shipment_total.to_s
+        end
+
+        def order_discount
+          @order
+            .line_item_adjustments
+            .nonzero
+            .promotion
+            .eligible
+            .reject { |a| a.source.promotion.discount? }
+            .sum(&:amount)
+            .to_s
         end
       end
     end

--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -39,7 +39,9 @@ module Spree
         def order_data(identifier, amount)
           identifier.merge(
             amount: amount,
-            order_id: order.number
+            order_id: order.number,
+            line_items: collect_line_items,
+            shipping_amount: order_shipping
           )
         end
 
@@ -103,6 +105,33 @@ module Spree
           else
             'failed'
           end
+        end
+
+        private
+
+        PAYPAL_MAX_LINEITEMS = 249
+
+        def collect_line_items
+          @order
+            .line_items
+            .reject { |li| li.price.zero? || li.quantity.zero? }
+            .map do |li|
+            {
+              name: li.name.truncate(127, omission: ''),
+              kind: 'debit',
+              quantity: li.quantity.to_s,
+              unit_amount: li.price.to_s,
+              unit_of_measure: 'unit',
+              product_code: li.sku,
+              total_amount: li.pre_tax_amount.to_s,
+              tax_amount: li.additional_tax_total.to_s
+              # discount_amount: '0.00'
+            }
+          end.take(PAYPAL_MAX_LINEITEMS)
+        end
+
+        def order_shipping
+          @order.shipment_total.to_s
         end
       end
     end


### PR DESCRIPTION
Paying with PayPal customer expects email from it with full line items list, including discount.
This patch provides collection LineItems and pushing it altogether with other fields.  