### PR TITLE
Braintree doesn't allow productCode over 12 characters, so we can't u…

### DIFF
--- a/app/models/spree/gateway/braintree_vzero_base/utils.rb
+++ b/app/models/spree/gateway/braintree_vzero_base/utils.rb
@@ -128,7 +128,7 @@ module Spree
               quantity: li.quantity.to_s,
               unit_amount: li.price.to_s,
               unit_of_measure: 'unit',
-              product_code: li.sku,
+              product_code: nil,
               total_amount: (li.price * li.quantity).to_s,
               tax_amount: li.additional_tax_total.to_s
             }


### PR DESCRIPTION
…se Product SKU for this purpose.